### PR TITLE
sudoers fix for homebrew-spawned utilities (Workaround for homebrew#105)

### DIFF
--- a/recipes/homebrew_sudoers.rb
+++ b/recipes/homebrew_sudoers.rb
@@ -27,13 +27,14 @@ directory '/etc/sudoers.d' do
   action :create
 end
 
-# Depends on attributes:
-#   node['lyraphase_workstation']['user']
-#   node['hostname']
 template '/etc/sudoers.d/homebrew_chef' do
   owner 'root'
   group 'wheel'
   mode '0644'
   source 'sudoers.d/homebrew_chef.erb'
+  variables({
+    :hostname => node['hostname'],
+    :user => node['lyraphase_workstation']['user']
+    })
   action :create
 end

--- a/recipes/homebrew_sudoers.rb
+++ b/recipes/homebrew_sudoers.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: lyraphase_workstation
+# Recipe:: homebrew_sudoers
+# Site:: https://github.com/chef-cookbooks/homebrew/issues/105
+#
+# Copyright (C) 2015-2017 James Cuzella
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+directory '/etc/sudoers.d' do
+  owner 'root'
+  group 'wheel'
+  mode '0755'
+  action :create
+end
+
+# Depends on attributes:
+#   node['lyraphase_workstation']['user']
+#   node['hostname']
+template '/etc/sudoers.d/homebrew_chef' do
+  owner 'root'
+  group 'wheel'
+  mode '0644'
+  source 'sudoers.d/homebrew_chef.erb'
+  action :create
+end

--- a/spec/unit/recipes/homebrew_sudoers_spec.rb
+++ b/spec/unit/recipes/homebrew_sudoers_spec.rb
@@ -19,15 +19,15 @@ require 'spec_helper'
 
 describe 'lyraphase_workstation::homebrew_sudoers' do
 
-  before(:all) do
-    # To use GitHub for latest platform (customink/fauxhai#201)
-    # edge: true
-    Fauxhai.mock(platform:'mac_os_x', version:'10.11.1') do |node|
-      node['hostname'] = 'bedrock'
-      Chef::Log.warn("INSIDE ChefSpec: node['hostname'] = #{node['hostname']}")
-      # node['lyraphase_workstation']['user'] = 'brubble'
-    end
-  end
+  # before(:all) do
+  #   # To use GitHub for latest platform (customink/fauxhai#201)
+  #   # edge: true
+  #   Fauxhai.mock(platform:'mac_os_x', version:'10.11.1') do |node|
+  #     node['hostname'] = 'bedrock'
+  #     Chef::Log.warn("INSIDE ChefSpec: node['hostname'] = #{node['hostname']}")
+  #     # node['lyraphase_workstation']['user'] = 'brubble'
+  #   end
+  # end
 
   let(:chef_run) {
     klass = ChefSpec.constants.include?(:SoloRunner) ? ChefSpec::SoloRunner : ChefSpec::Runner
@@ -36,7 +36,7 @@ describe 'lyraphase_workstation::homebrew_sudoers' do
       node.set['etc']['passwd']['brubble'] = Struct::EtcPasswd.new('brubble', '********', 501, 20, 'Barney Rubble', '/Users/brubble', '/bin/bash', 0, '', 0)
       node.set['lyraphase_workstation']['user'] = 'brubble'
       node.set['lyraphase_workstation']['home'] = '/Users/brubble'
-      node.set['hostname'] = 'bedrock'
+      node.automatic['hostname'] = 'bedrock'
     end.converge(described_recipe)
   }
 
@@ -70,7 +70,7 @@ describe 'lyraphase_workstation::homebrew_sudoers' do
     )
     expected_commands.each do |expected_command|
       expect(chef_run).to render_file('/etc/sudoers.d/homebrew_chef').with_content(
-        Regexp.new("^brubble\s+bedrock=\(root\)\s+NOPASSWD:SETENV:\s+#{expected_command}$")
+        Regexp.new("^brubble\\s+bedrock=\\(root\\)\\s+NOPASSWD:SETENV:\\s+#{expected_command}$")
       )
     end
   end

--- a/spec/unit/recipes/homebrew_sudoers_spec.rb
+++ b/spec/unit/recipes/homebrew_sudoers_spec.rb
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 James Cuzella
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+
+describe 'lyraphase_workstation::homebrew_sudoers' do
+
+  before(:all) do
+    # To use GitHub for latest platform (customink/fauxhai#201)
+    # edge: true
+    Fauxhai.mock(platform:'mac_os_x', version:'10.11.1') do |node|
+      node['hostname'] = 'bedrock'
+      Chef::Log.warn("INSIDE ChefSpec: node['hostname'] = #{node['hostname']}")
+      # node['lyraphase_workstation']['user'] = 'brubble'
+    end
+  end
+
+  let(:chef_run) {
+    klass = ChefSpec.constants.include?(:SoloRunner) ? ChefSpec::SoloRunner : ChefSpec::Runner
+    klass.new do |node|
+      create_singleton_struct "EtcPasswd", [ :name, :passwd, :uid, :gid, :gecos, :dir, :shell, :change, :uclass, :expire ]
+      node.set['etc']['passwd']['brubble'] = Struct::EtcPasswd.new('brubble', '********', 501, 20, 'Barney Rubble', '/Users/brubble', '/bin/bash', 0, '', 0)
+      node.set['lyraphase_workstation']['user'] = 'brubble'
+      node.set['lyraphase_workstation']['home'] = '/Users/brubble'
+      node.set['hostname'] = 'bedrock'
+    end.converge(described_recipe)
+  }
+
+
+  it 'creates /etc/sudoers.d directory' do
+    expect(chef_run).to create_directory('/etc/sudoers.d').with(
+      user:  'root',
+      group: 'wheel',
+      mode:  '0755'
+    )
+  end
+
+  let(:expected_commands) {
+    [
+      '/bin/chmod',
+      '/usr/sbin/chown',
+      '/bin/mkdir',
+      '/usr/bin/chgrp',
+      '/usr/bin/touch',
+      '/usr/sbin/softwareupdate',
+      '/bin/rm',
+      '/usr/sbin/installer'
+    ]
+  }
+
+  it 'installs /etc/sudoers.d/homebrew_chef' do
+    expect(chef_run).to create_template('/etc/sudoers.d/homebrew_chef').with(
+      user:  'root',
+      group: 'wheel',
+      mode:  '0644'
+    )
+    expected_commands.each do |expected_command|
+      expect(chef_run).to render_file('/etc/sudoers.d/homebrew_chef').with_content(
+        Regexp.new("^brubble\s+bedrock=\(root\)\s+NOPASSWD:SETENV:\s+#{expected_command}$")
+      )
+    end
+  end
+end
+

--- a/templates/default/sudoers.d/homebrew_chef.erb
+++ b/templates/default/sudoers.d/homebrew_chef.erb
@@ -1,11 +1,11 @@
 # From https://github.com/chef-cookbooks/homebrew/issues/105
 # Allow NOPASSWD for homebrew actions
 Defaults:<%- node['lyraphase_workstation']['user'] -%>         env_keep += "ARCHFLAGS PKG_CONFIG_PATH GOPATH PYTHONPATH COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS GIT_WORK_TREE GIT_DIR HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY", !requiretty
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /bin/chmod
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/sbin/chown
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /bin/mkdir
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/bin/chgrp
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/bin/touch
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/sbin/softwareupdate
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /bin/chmod
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/sbin/chown
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /bin/mkdir
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/bin/chgrp
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/bin/touch
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/sbin/softwareupdate
 <%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /bin/rm
 <%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/sbin/installer

--- a/templates/default/sudoers.d/homebrew_chef.erb
+++ b/templates/default/sudoers.d/homebrew_chef.erb
@@ -1,0 +1,11 @@
+# From https://github.com/chef-cookbooks/homebrew/issues/105
+# Allow NOPASSWD for homebrew actions
+Defaults:<%- node['lyraphase_workstation']['user'] -%>         env_keep += "ARCHFLAGS PKG_CONFIG_PATH GOPATH PYTHONPATH COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS GIT_WORK_TREE GIT_DIR HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY", !requiretty
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /bin/chmod
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/sbin/chown
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /bin/mkdir
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/bin/chgrp
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/bin/touch
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD: /usr/sbin/softwareupdate
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /bin/rm
+<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/sbin/installer

--- a/templates/default/sudoers.d/homebrew_chef.erb
+++ b/templates/default/sudoers.d/homebrew_chef.erb
@@ -1,11 +1,11 @@
 # From https://github.com/chef-cookbooks/homebrew/issues/105
 # Allow NOPASSWD for homebrew actions
-Defaults:<%- node['lyraphase_workstation']['user'] -%>         env_keep += "ARCHFLAGS PKG_CONFIG_PATH GOPATH PYTHONPATH COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS GIT_WORK_TREE GIT_DIR HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY", !requiretty
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /bin/chmod
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/sbin/chown
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /bin/mkdir
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/bin/chgrp
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/bin/touch
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/sbin/softwareupdate
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /bin/rm
-<%- node['lyraphase_workstation']['user'] -%> <%- node['hostname'] -%>=(root) NOPASSWD:SETENV: /usr/sbin/installer
+Defaults:<%- @user -%>         env_keep += "ARCHFLAGS PKG_CONFIG_PATH GOPATH PYTHONPATH COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR LS_COLORS GIT_WORK_TREE GIT_DIR HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY", !requiretty
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /bin/chmod
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /usr/sbin/chown
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /bin/mkdir
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /usr/bin/chgrp
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /usr/bin/touch
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /usr/sbin/softwareupdate
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /bin/rm
+<%= @user -%> <%= @hostname -%>=(root) NOPASSWD:SETENV: /usr/sbin/installer


### PR DESCRIPTION
Allow root permissions for utilities spawned by `brew install` with `sudo` or `sudo -E`