### PR TITLE
lyraphase_workstation::gpg21: Fix loading gpg-agent LaunchAgent

### DIFF
--- a/recipes/gpg21.rb
+++ b/recipes/gpg21.rb
@@ -80,5 +80,5 @@ end
 execute "load the fixGpgHome / gpg-agent plist into launchd" do
   command "launchctl load -w /Library/LaunchAgents/com.lyraphase.gpg21.fix.plist"
   user node['lyraphase_workstation']['user']
-  not_if { 'launchctl list com.lyraphase.gpg21.fix' }
+  not_if 'launchctl list com.lyraphase.gpg21.fix'
 end

--- a/recipes/gpg21.rb
+++ b/recipes/gpg21.rb
@@ -58,6 +58,7 @@ template "/Library/LaunchAgents/com.lyraphase.gpg21.fix.plist" do
   user node['lyraphase_workstation']['user']
   mode "0644"
   # No variables for now
+  notifies :run, 'execute[load the fixGpgHome / gpg-agent plist into launchd]'
 end
 
 plist_file gpgtools_launchagent_plist_file do
@@ -74,4 +75,10 @@ ruby_block "add StreamLocalBindUnlink to sshd config" do
   block do
     add_streamlocalbindunlink_to_sshd_config
   end
+end
+
+execute "load the fixGpgHome / gpg-agent plist into launchd" do
+  command "launchctl load -w /Library/LaunchAgents/com.lyraphase.gpg21.fix.plist"
+  user node['lyraphase_workstation']['user']
+  not_if { 'launchctl list com.lyraphase.gpg21.fix' }
 end

--- a/spec/unit/recipes/gpg21_spec.rb
+++ b/spec/unit/recipes/gpg21_spec.rb
@@ -63,10 +63,23 @@ describe 'lyraphase_workstation::gpg21' do
     )
     expect(chef_run).to render_file(launchd_plist).with_content(Regexp.new("^\\s+<string>#{Regexp.escape(fixGpgHome_script_path)}</string>$"))
     expect(chef_run).to render_file(launchd_plist).with_content(Regexp.new("^\\s+<string>#{Regexp.escape(File.basename(launchd_plist).gsub(/\.plist$/, ''))}</string>$"))
+
+    expect(chef_run.template(launchd_plist)).to notify('execute[load the fixGpgHome / gpg-agent plist into launchd]').to(:run)
   end
 
   it "disables the gpgtools launchd plist file" do
     expect(chef_run).to update_plist_file(gpgtools_plist_file_test)
+  end
+
+  context "when launchd plist is already loaded" do
+    before(:all) do
+      stub_command('launchctl list com.lyraphase.gpg21.fix').and_return(true)
+    end
+
+    it "loads our fixGpgHome / gpg-agent launchd plist file" do
+      expect(chef_run.execute('load the fixGpgHome / gpg-agent plist into launchd')).to do_nothing
+    end
+
   end
 
   context 'when gpg binary symlinks exist' do

--- a/spec/unit/recipes/gpg21_spec.rb
+++ b/spec/unit/recipes/gpg21_spec.rb
@@ -35,6 +35,7 @@ describe 'lyraphase_workstation::gpg21' do
       stub_command("which git").and_return('/usr/local/bin/git')
 
       node.normal['lyraphase_workstation']['gpg21']['binary_paths'] = []
+      stub_command('launchctl list com.lyraphase.gpg21.fix').and_return(true)
     end.converge(described_recipe)
   }
 
@@ -115,6 +116,7 @@ describe 'lyraphase_workstation::gpg21' do
       stub_command("which git").and_return('/usr/local/bin/git')
 
       node.normal['lyraphase_workstation']['gpg21']['binary_paths'] = gpg_binary_paths
+      stub_command('launchctl list com.lyraphase.gpg21.fix').and_return(true)
     end.converge(described_recipe)
   }
 
@@ -165,6 +167,7 @@ describe 'lyraphase_workstation::gpg21' do
       stub_command("which git").and_return('/usr/local/bin/git')
 
       node.normal['lyraphase_workstation']['gpg21']['binary_paths'] = gpg_binary_paths
+      stub_command('launchctl list com.lyraphase.gpg21.fix').and_return(true)
     end.converge(described_recipe)
   }
     before(:each) do


### PR DESCRIPTION
- Load the `com.lyraphase.gpg21.fix` LaunchAgent when `/Library/LaunchAgents/com.lyraphase.gpg21.fix.plist` template renders changes
- Skip loading LaunchAgent when `launchctl list com.lyraphase.gpg21.fix` returns zero exit status