### PR TITLE
Update ableton live to v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ script:
   - rake knife
   - rake foodcritic
   - rake chefspec
-  - find /opt/chefdk/embedded/lib/ruby/gems/ -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*'
-  - find /opt/chefdk/embedded/lib/ruby/gems/ -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*' -exec chmod 777 '{}' \;
+  - find /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems  -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*'
   - cat /opt/chefdk/version-manifest.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ script:
   - rake knife
   - rake foodcritic
   - rake chefspec
-  - find /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems  -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*'
+  - find /opt/chefdk/embedded/lib/ruby/gems/  -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*'
   - cat /opt/chefdk/version-manifest.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - rake knife
   - rake foodcritic
   - rake chefspec
-  - find /opt/chefdk/embedded/lib/ruby/gems/2.3.0/gems  -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*'
+  - find /opt/chefdk/embedded/lib/ruby/gems/ -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*'
+  - find /opt/chefdk/embedded/lib/ruby/gems/ -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*' -exec chmod 777 '{}' \;
   - cat /opt/chefdk/version-manifest.txt
 

--- a/Berksfile
+++ b/Berksfile
@@ -8,7 +8,8 @@ end
 cookbook 'sprout-base', '~> 0.1', :github => 'pivotal-sprout/sprout-base'
 cookbook 'osx', '~> 0.1.0', :github => 'pivotal-sprout/osx'
 
-cookbook 'plist', '~> 0.9', :github => 'trinitronx/chef-plist', rel: 'vendor/cookbooks/plist', :branch => 'add-chefspec-matchers'
+cookbook 'plist', '~> 0.9.4', :github => 'trinitronx/chef-plist', rel: 'vendor/cookbooks/plist', :branch => 'develop'
+#OLD = :branch => 'add-chefspec-matchers'
 
 cookbook 'homebrew', '>= 1.13.0'
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,160 @@ This includes Ableton Live [DAW][1], VSTs, and other various tools and utilities
 
 # Usage
 
+Include the recipes you want in your Chef `run_list`, or in your [`soloistrc` file][sprout-wrap].
+
+**NOTE:** The default URLs for non-free applications **will not work for you**.  You must host your own `.dmg` and app install files.  Please see the recipe's cooresponding `attributes` file for examples.  All checksums are SHA256, and can be found via `shasum -a 256 path/to/file/here.dmg`.
+
+You may decide to create a DAW Chef Role such as:
+
+`roles/osx-daw.json`:
+
+    {
+      "json_class": "Chef::Role",
+      "name": "osx-daw",
+      "description": "Role for configuring OSX as a Digital Audio Workstation",
+      "override_attributes": {
+        "homebrew": {
+          "casks": [
+            "keyfinder",
+            "soundflower",
+            "audacity"
+          ]
+        },
+        "lyraphase_workstation": {
+          "ableton_live": {
+            "managed_versions": "all",
+            "options": ["EnableMapToSiblings"],
+            "dmg": {
+              "source": "http://www.example.com/mac/dmgs/ableton_live_suite_10.0.1_64.dmg",
+              "checksum": "73f8b7d9c2e058639466cbb765e6e1610f97f542745e2c69567d7bf55a407e11",
+              "volumes_dir": "Ableton Live 10 Suite Installer",
+              "dmg_name": "ableton_live_suite_10.0.1_64",
+              "app": "Ableton Live 10 Suite"
+            }
+          }
+        }
+      },
+      "run_list": [
+        "recipe[lyraphase_workstation::airfoil]",
+        "recipe[lyraphase_workstation::ableton_live]",
+        "recipe[lyraphase_workstation::ableton_live_options]",
+        "recipe[lyraphase_workstation::max_for_live]",
+        "recipe[lyraphase_workstation::traktor]",
+        "recipe[lyraphase_workstation::traktor_audio_2]",
+        "recipe[lyraphase_workstation::dmgaudio_dualism]",
+        "recipe[lyraphase_workstation::oxium]",
+        "recipe[lyraphase_workstation::polyverse_infected_mushroom_i_wish]",
+        "recipe[lyraphase_workstation::mixed_in_key]",
+        "recipe[lyraphase_workstation::korg_kontrol_editor]",
+        "recipe[lyraphase_workstation::sublime_text_settings]",
+        "recipe[lyraphase_workstation::nfs_mounts]",
+        "recipe[lyraphase_workstation::bash_it_custom_plugins]",
+        "recipe[lyraphase_workstation::daisydisk]",
+        "recipe[lyraphase_workstation::drobo_dashboard]",
+        "recipe[lyraphase_workstation::prolific_pl2303_driver]"
+      ]
+    }
+
+There are also some non-DAW related recipes included in this cookbook.
+
+You may also decide to create a development tool Chef Role such as:
+
+`roles/osx-development.json`:
+
+    {
+      "json_class": "Chef::Role",
+      "name": "osx-development",
+      "description": "Role for configuring OSX with developer tools",
+      "override_attributes": {
+        "lyraphase_workstation": {
+          "nfs_mounts": [
+            "/../Volumes/my-nfs-mount    -fstype=nfs,nolockd,resvport,hard,bg,intr,rw,tcp,nfc nfs://nfs-server.example.com:/export/my-nfs-mount"
+          ]
+        }
+      },
+      "run_list": [
+        "recipe[sublime_text_settings]",
+        "recipe[nfs_mounts]",
+        "recipe[homebrew_sudoers]",
+        "recipe[iterm2_shell_integration]",
+        "recipe[bash4]",
+        "recipe[bash_it_custom_plugins]",
+        "recipe[gpg21]"
+      ]
+    }
+
+To use the `sublime_text_settings` recipe, place your Sublime Text 3 Application Data folders under `"#{node['lyraphase_workstation']['home']}/Dropbox/AppData/mac/sublime-text-3/`.  The recipe will create [Symbolic Links][symlink] to these files in the usual location: `"#{node['lyraphase_workstation']['home']}/Library/Application Support/Sublime Text 3/`.
+
+The result is that your Sublime Text 3 folders get synced to Dropbox, and Sublime Text can look for them in the default location, follow the symlink to the Dropbox destination files.
+
+The `nfs_mounts` recipe will just mount things in the list of `nfs_mounts` for you.  The `/../` part in front of `/../Volumes/` happens to be important!  The reason is because the OSX `/etc/auto_nfs` file does not usually want to mount things under `/Volumes`.  Putting the `/../` in front allows you to use automount to mount NFS volumes there.
+
+The `homebrew_sudoers` recipe uses the included `templates/default/sudoers.d/homebrew_chef.erb` template to fix `sudo` permissions when running `chef-client` or `soloist` to provision your OSX machine.  Without this, you may be asked for `sudo` password far too many times than is feasible to type.  The included `sudoers.d` file drop-in allows the [`homebrew` cookbook][homebrew-cookbook] to run the [commands it needs][homebrew-sudo-bug] via passwordless `sudo`.
+
+The `iterm2_shell_integration` recipe installs iTerm via `iterm` recipe, and then [iTerm2 Shell Integration][iterm2-shell] via script url `https://iterm2.com/misc/install_shell_integration.sh`. Checksum may not be kept up to date, but you can change this.  See the recipe's attributes (`attributes/iterm2_shell_integration.rb`).
+
+The `iterm` recipe installs iTerm via [Homebrew](https://brew.sh). It then installs my default preferences file via template `templates/default/com.googlecode.iterm2.plist.erb`.  You may not want this and may want to use a wrapper cookbook that just calls `include_recipe 'iterm'` so you can override my template.
+
+
+The `bash4` recipe installs Bash version 4 via Homebrew and changes your login shell. It also configures `/etc/shells` with a list of shells from attribute `node['lyraphase_workstation']['bash']['etc_shells']`. If you do not want to reset your login shell to bash from Homebrew, set `default['lyraphase_workstation']['bash']['set_login_shell'] = false`. The `etc_shells_path` is also configurable (see `attributes/bash4.rb`).
+
+The `bash_it_custom_plugins` recipe uses `sprout-base::bash_it` to install a list of plugins for [Bash-it][bash-it].  The default list is in `node.default['lyraphase_workstation']['bash_it']['custom_plugins']`.  See the [`sprout-base` cookbook][sprout-base] for more details.
+
+The `gpg21` recipe installs GnuPG version 2.1 via `homebrew/versions` Homebrew Tap. It ensures that old symlinks to gpg binaries are deleted (configurable via `node['lyraphase_workstation']['gpg21']['binary_paths']`).  Only symlinks are unlinked, no old binaries should be harmed.  The recipe also installs a helper script to `/usr/local/bin/fixGpgHome`, and a `LaunchAgents` to `/Library/LaunchAgents/com.lyraphase.gpg21.fix.plist`.  Finally, it sets `RunAtLoad: false` for the original `/Library/LaunchAgents/org.gpgtools.macgpg2.fix.plist` file.  The reason for this set of patches is because the original LaunchAgent has hardcoded references to the old GnuPG binaries, and you may end up getting confused as to which version of GPG you are really using from `gpg-agent`, `gpg`, and `gpg2`.  This recipe sets them all to the new `gpg21` binaries from Homebrew.  Finally, it adds `StreamLocalBindUnlink yes` to your `/etc/ssh/sshd_config` so you may use `gpg-agent` forwarding over SSH.
+
+
 # Attributes
 
+Too many to list!  Please see the appropriate recipe's `attributes/<recipe_here>.rb` file for details.
+
+Some general rules of thumb:
+
+ - `.dmg` file installers usually have the following attributes:
+   - `['lyraphase_workstation']['recipe_here']['dmg']`: A set of attributes describing the DMG such as:
+     - `['source']`: A source URL for Chef to download the DMG installer from.  **You must set your own!** I do not intend to host these for anyone else!
+     - `['checksum']`: A SHA256 checksum of the `.dmg` file.  Get this via `shasum -a 256 your-file.dmg` OR on *nix systems `sha256sum your-file.dmg`.
+     - `['volumes_dir']`: Directory name that the `.dmg` will expected to be mounted under `/Volumes/`.
+     - `['dmg_name']`: Name of the `.dmg` file without the `.dmg` suffix.  That's it!
+     - `['app']`: Name of the `.app` folder inside the mounted `.dmg`.  This maps to `/Volumes/dmg_name/app_name_here.app`.
+     - `['type']`: Type of application the [dmg cookbook][dmg-cookbook] will install.  This can be one of: `app`, `mkpg`, `pkg`. **Default: '`app`'**
+ - `.zip` file app installations usually have these attributes:
+   - `['lyraphase_workstation']['recipe_here']['zip']`: A set of attributes describing the `.zip` file:
+     - `['zip']['source']`: A source URL for Chef to download the ZIP archive from.  **Again: You must set your own!** I do not intend to host these for anyone else!
+     - `['zip']['checksum']`:  A SHA256 checksum of the `.zip` file.  Get this via `shasum -a 256 your-file.zip` OR on *nix systems `sha256sum your-file.zip`.
+ - Some recipes have support for License Keys. To use these there are two methods:
+     - `['license']` data inside Chef Attributes
+       - Just set the attributes like you normally would and the recipe will use them
+     - `['license']` data inside [Encrypted Data Bags][data-bags]
+       - Check the recipe `.rb` file for the Encrypted Data Bag name, then create an encrypted data bag with the same data structure as you would put under `['license']`.  You may wish to use the [`knife-solo_data_bag` gem][knife-solo_data_bag] to assist in operating on plain files.  If you have a Chef Server, use the normal `knife` commands to operate on the data bags.
+       - If the recipe finds an Encrypted Data Bag with `['license']` data (`Hash`), it will override the Attributes and use this instead.
+
 # Recipes
+
+ - `lyraphase_workstation::ableton_live`: Install [Ableton Live](https://www.ableton.com/) DAW
+ - `lyraphase_workstation::ableton_live_options`: Manage [Options.txt](https://help.ableton.com/hc/en-us/articles/209772865-Options-txt-file-for-Live) settings for [Ableton Live](https://www.ableton.com/) DAW
+ - `lyraphase_workstation::airfoil`: Install [Airfoil](https://www.rogueamoeba.com/airfoil/)
+ - `lyraphase_workstation::bash4`: Install [bash v4](https://github.com/Homebrew/homebrew-core/blob/master/Formula/bash.rb) from Homebrew
+ - `lyraphase_workstation::cycling_74_max`: Install [CYCLING '74 MAX](https://cycling74.com/)
+ - `lyraphase_workstation::daisydisk`: Install [DaisyDisk](http://www.daisydiskapp.com/)
+ - `lyraphase_workstation::default`: No-Op recipe for just loading libraries this cookbook provides
+ - `lyraphase_workstation::dmgaudio_dualism`: Install [DMGAudio Dualism](http://www.dmgaudio.com/products_dualism.php)
+ - `lyraphase_workstation::drobo_dashboard`: Install [Drobo Dashboard](http://www.drobo.com/start/)
+ - `lyraphase_workstation::korg_kontrol_editor`: Install [Korg Kontrol Editor](http://www.korg.com/us/support/download/software/1/253/1355/) ([Manual](http://www.korg.com/us/support/download/manual/1/253/1843/) [Archived DL](https://web.archive.org/web/20150919212752/http://www.korg.com/filedl/61a78cbcf754384af8104114d7cde1c7/840/download.php))
+ - `lyraphase_workstation::max_for_live`: Install [Max for Live](https://www.ableton.com/en/live/max-for-live/)
+ - `lyraphase_workstation::mixed_in_key`: Install [Mixed In Key](http://www.mixedinkey.com)
+ - `lyraphase_workstation::multibit`: Install [Multibit](https://multibit.org/)
+ - `lyraphase_workstation::musicbrainz_picard`: Install [MusicBrainz Picard](https://picard.musicbrainz.org/)
+ - `lyraphase_workstation::nfs_mounts`: Manage /etc/auto_nfs entries for [NFS Client mounts on OS X](https://coderwall.com/p/fuoa-g/automounting-nfs-share-in-os-x-into-volumes)
+ - `lyraphase_workstation::omnifocus`: Install [OmniFocus](https://www.omnigroup.com/omnifocus)
+ - `lyraphase_workstation::oxium`: Install [Xils-Lab Oxium](http://www.xils-lab.com/pages/Oxium.html) Synthesizer
+ - `lyraphase_workstation::polyverse_infected_mushroom_i_wish`: Install [Polyverse - Infected Mushroom - I Wish VST](http://polyversemusic.com/)
+ - `lyraphase_workstation::prolific_pl2303_driver`: Install [Prolific PL2303 Driver](http://www.prolific.com.tw/US/ShowProduct.aspx?p_id=229&pcid=41)
+ - `lyraphase_workstation::sublime_text_settings`: Installs Settings symlinks for storing [Sublime Text](http://www.sublimetext.com/) configs in Dropbox
+ - `lyraphase_workstation::traktor`: Installs [Traktor](http://www.native-instruments.com/en/products/traktor/) DJ software
+ - `lyraphase_workstation::traktor_audio_2`: Installs [Traktor Audio 2 DJ](http://www.native-instruments.com/en/products/traktor/dj-audio-interfaces/traktor-audio-2/) Driver
+ - `lyraphase_workstation::vimrc`: Installs vimrc via git repo
+ - `lyraphase_workstation::xcode`: Install XCode via .dmg and accepts XCode build license
 
 # Author
 
@@ -22,3 +173,13 @@ Author:: James Cuzella ([@trinitronx][keybase-id])
 
 [1]: https://en.wikipedia.org/wiki/Digital_audio_workstation
 [keybase-id]: https://gist.github.com/trinitronx/aee110cbdf55e67185dc44272784e694
+[sprout-wrap]: https://github.com/trinitronx/sprout-wrap/
+[dmg-cookbook]: https://github.com/chef-cookbooks/dmg
+[data-bags]: https://docs.chef.io/data_bags.html
+[knife-solo_data_bag]: https://github.com/thbishop/knife-solo_data_bag
+[symlink]: https://en.wikipedia.org/wiki/Symbolic_link
+[homebrew-cookbook]: https://github.com/chef-cookbooks/homebrew
+[homebrew-sudo-bug]: https://github.com/chef-cookbooks/homebrew/issues/105
+[iterm2-shell]: https://www.iterm2.com/documentation-shell-integration.html
+[bash-it]: https://github.com/Bash-it/bash-it
+[sprout-base]: https://github.com/pivotal-sprout/sprout-base

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 lyraphase_workstation cookbook
 ==============================
+<noscript><a href="https://liberapay.com/trinitronx/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a></noscript>
 [![Build Status](http://img.shields.io/travis/trinitronx/lyraphase_workstation.svg)](https://travis-ci.org/trinitronx/lyraphase_workstation)
-[![Gittip](http://img.shields.io/gittip/trinitronx.svg)](https://www.gittip.com/trinitronx)
 
 A cookbook including various recipes for installing tools used by myself.
 This includes Ableton Live [DAW][1], VSTs, and other various tools and utilities.

--- a/attributes/ableton_live.rb
+++ b/attributes/ableton_live.rb
@@ -1,8 +1,8 @@
 default['lyraphase_workstation']['ableton_live'] = {}
 default['lyraphase_workstation']['ableton_live']['dmg'] = {}
-default['lyraphase_workstation']['ableton_live']['dmg']['source']      = 'http://www.lyraphase.com/doc/installers/mac/ableton_live_suite_9.7_64.dmg'
-default['lyraphase_workstation']['ableton_live']['dmg']['checksum']    = "35fa16a2c703d458fc005413e81e7fccd3ebf18eff5bffea91eb9165db42c400"
-default['lyraphase_workstation']['ableton_live']['dmg']['volumes_dir'] = "Ableton Live 9 Suite Installer"
-default['lyraphase_workstation']['ableton_live']['dmg']['dmg_name']    = 'ableton_live_suite_9.7_64'
-default['lyraphase_workstation']['ableton_live']['dmg']['app']         = 'Ableton Live 9 Suite'
+default['lyraphase_workstation']['ableton_live']['dmg']['source']      = 'http://www.lyraphase.com/doc/installers/mac/ableton_live_suite_10.0.1_64.dmg'
+default['lyraphase_workstation']['ableton_live']['dmg']['checksum']    = "73f8b7d9c2e058639466cbb765e6e1610f97f542745e2c69567d7bf55a407e11"
+default['lyraphase_workstation']['ableton_live']['dmg']['volumes_dir'] = "Ableton Live 10 Suite Installer"
+default['lyraphase_workstation']['ableton_live']['dmg']['dmg_name']    = 'ableton_live_suite_10.0.1_64'
+default['lyraphase_workstation']['ableton_live']['dmg']['app']         = 'Ableton Live 10 Suite'
 default['lyraphase_workstation']['ableton_live']['dmg']['type']        = 'app'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             "lyraphase_workstation"
 maintainer       "James Cuzella"
 maintainer_email "james.cuzella@lyraphase.com"
-license          "GNU Public License 3.0"
+license          "GPL-3.0+"
 description      "Recipes to Install & Configure my workstation"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.5.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "james.cuzella@lyraphase.com"
 license          "GPL-3.0+"
 description      "Recipes to Install & Configure my workstation"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.5.0"
+version          "1.6.0"
 chef_version     ">= 12.0" if respond_to?(:chef_version)
 
 source_url 'https://github.com/trinitronx/lyraphase_workstation' if respond_to?(:source_url)

--- a/recipes/ableton_live.rb
+++ b/recipes/ableton_live.rb
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# node.set['lyraphase_workstation']['ableton_live']['dmg'] = {}
+# node.default['lyraphase_workstation']['ableton_live']['dmg'] = {}
 # Chef::Log.warn("INSIDE RECIPE: is node['lyraphase_workstation']['ableton_live']['dmg'] a kind of Hash? #{node['lyraphase_workstation']['ableton_live']['dmg'].kind_of?(Hash)}")
 # Chef::Log.warn("INSIDE RECIPE: Class of node['lyraphase_workstation']['ableton_live']['dmg'] is: #{node['lyraphase_workstation']['ableton_live']['dmg'].class}")
 # Chef::Log.warn("INSIDE RECIPE: debug_value of node['lyraphase_workstation']['ableton_live']['dmg']:")

--- a/recipes/airfoil.rb
+++ b/recipes/airfoil.rb
@@ -22,7 +22,7 @@
 
 homebrew_cask "airfoil"
 
-license_info = Chef::EncryptedDataBagItem.load('lyraphase_workstation', 'airfoil')['license'] rescue nil
+license_info = data_bag_item('lyraphase_workstation', 'airfoil')['license'] rescue nil
 if license_info.nil? && ! node['lyraphase_workstation']['airfoil'].nil? && ! node['lyraphase_workstation']['airfoil']['license'].nil? && ! node['lyraphase_workstation']['airfoil']['license']['name'].nil? && ! node['lyraphase_workstation']['airfoil']['license']['code'].nil?
   license_info = node['lyraphase_workstation']['airfoil']['license']
 end

--- a/recipes/daisydisk.rb
+++ b/recipes/daisydisk.rb
@@ -55,7 +55,7 @@ recursive_directories([app_supportdir, "DaisyDisk"]) do
   owner node['lyraphase_workstation']['user']
 end
 
-license_data = Chef::EncryptedDataBagItem.load('lyraphase_workstation', 'daisydisk')['license'] rescue nil
+license_data = data_bag_item('lyraphase_workstation', 'daisydisk')['license'] rescue nil
 
 if license_data.nil? && ! node['lyraphase_workstation']['daisydisk']['license'].nil? && ! node['lyraphase_workstation']['daisydisk']['license']['customer_name'].nil? && ! node['lyraphase_workstation']['daisydisk']['license']['registration_key'].nil?
   license_data = node['lyraphase_workstation']['daisydisk']['license']

--- a/recipes/dmgaudio_dualism.rb
+++ b/recipes/dmgaudio_dualism.rb
@@ -52,7 +52,7 @@ end
 
 dmgaudio_dualism_appsupport_dir = "#{node['lyraphase_workstation']['home']}/Library/Application Support/DMGAudio/Dualism"
 
-license_key_data = Chef::EncryptedDataBagItem.load('lyraphase_workstation', 'dmgaudio_dualism') rescue nil
+license_key_data = data_bag_item('lyraphase_workstation', 'dmgaudio_dualism') rescue nil
 
 if license_key_data.nil? && ! node['lyraphase_workstation']['dmgaudio_dualism']['license_key'].nil?
   license_key_data = node['lyraphase_workstation']['dmgaudio_dualism']

--- a/recipes/mixed_in_key.rb
+++ b/recipes/mixed_in_key.rb
@@ -31,7 +31,7 @@ dmg_package "Mixed In Key" do
   action :install
 end
 
-license_key_data = Chef::EncryptedDataBagItem.load('lyraphase_workstation', 'mixed_in_key')['license'] rescue nil
+license_key_data = data_bag_item('lyraphase_workstation', 'mixed_in_key')['license'] rescue nil
 
 if license_key_data.nil? && ! node['lyraphase_workstation']['mixed_in_key']['license'].nil? && ! node['lyraphase_workstation']['mixed_in_key']['license']['vipcode']
   license_key_data = node['lyraphase_workstation']['mixed_in_key']['license']

--- a/recipes/polyverse_infected_mushroom_i_wish.rb
+++ b/recipes/polyverse_infected_mushroom_i_wish.rb
@@ -40,7 +40,7 @@ recursive_directories([user_library_dir, "Polyverse"]) do
   owner node['lyraphase_workstation']['user']
 end
 
-license_data = Chef::EncryptedDataBagItem.load('lyraphase_workstation', 'polyverse_infected_mushroom_i_wish')['license'] rescue nil
+license_data = data_bag_item('lyraphase_workstation', 'polyverse_infected_mushroom_i_wish')['license'] rescue nil
 
 if license_data.nil? && ! node['lyraphase_workstation']['polyverse_infected_mushroom_i_wish']['license'].nil? && ! node['lyraphase_workstation']['polyverse_infected_mushroom_i_wish']['license']['email'].nil? && ! node['lyraphase_workstation']['polyverse_infected_mushroom_i_wish']['license']['key'].nil?
   license_data = node['lyraphase_workstation']['polyverse_infected_mushroom_i_wish']['license']

--- a/recipes/polyverse_infected_mushroom_manipulator.rb
+++ b/recipes/polyverse_infected_mushroom_manipulator.rb
@@ -40,7 +40,7 @@ recursive_directories([user_library_dir, "Polyverse", "Manipulator"]) do
   owner node['lyraphase_workstation']['user']
 end
 
-license_data = Chef::EncryptedDataBagItem.load('lyraphase_workstation', 'polyverse_infected_mushroom_manipulator')['license'] rescue nil
+license_data = data_bag_item('lyraphase_workstation', 'polyverse_infected_mushroom_manipulator')['license'] rescue nil
 
 if license_data.nil? && ! node['lyraphase_workstation']['polyverse_infected_mushroom_manipulator']['license'].nil? && ! node['lyraphase_workstation']['polyverse_infected_mushroom_manipulator']['license']['email'].nil? && ! node['lyraphase_workstation']['polyverse_infected_mushroom_manipulator']['license']['key'].nil?
   license_data = node['lyraphase_workstation']['polyverse_infected_mushroom_manipulator']['license']

--- a/recipes/trackspacer.rb
+++ b/recipes/trackspacer.rb
@@ -32,7 +32,7 @@ dmg_package "Trackspacer" do
   action :install
 end
 
-license_key_data = Chef::EncryptedDataBagItem.load('lyraphase_workstation', 'trackspacer')['license'] rescue nil
+license_key_data = data_bag_item('lyraphase_workstation', 'trackspacer')['license'] rescue nil
 
 if license_key_data.nil? && ! node['lyraphase_workstation']['trackspacer']['license'].nil? && ! node['lyraphase_workstation']['trackspacer']['license']['serial']
   license_key_data = node['lyraphase_workstation']['trackspacer']['license']

--- a/spec/unit/recipes/homebrew_sudoers_spec.rb
+++ b/spec/unit/recipes/homebrew_sudoers_spec.rb
@@ -33,9 +33,9 @@ describe 'lyraphase_workstation::homebrew_sudoers' do
     klass = ChefSpec.constants.include?(:SoloRunner) ? ChefSpec::SoloRunner : ChefSpec::Runner
     klass.new do |node|
       create_singleton_struct "EtcPasswd", [ :name, :passwd, :uid, :gid, :gecos, :dir, :shell, :change, :uclass, :expire ]
-      node.set['etc']['passwd']['brubble'] = Struct::EtcPasswd.new('brubble', '********', 501, 20, 'Barney Rubble', '/Users/brubble', '/bin/bash', 0, '', 0)
-      node.set['lyraphase_workstation']['user'] = 'brubble'
-      node.set['lyraphase_workstation']['home'] = '/Users/brubble'
+      node.default['etc']['passwd']['brubble'] = Struct::EtcPasswd.new('brubble', '********', 501, 20, 'Barney Rubble', '/Users/brubble', '/bin/bash', 0, '', 0)
+      node.default['lyraphase_workstation']['user'] = 'brubble'
+      node.default['lyraphase_workstation']['home'] = '/Users/brubble'
       node.automatic['hostname'] = 'bedrock'
     end.converge(described_recipe)
   }

--- a/spec/unit/recipes/osx_natural_scrolling.rb
+++ b/spec/unit/recipes/osx_natural_scrolling.rb
@@ -18,7 +18,7 @@ describe 'lyraphase_workstation::osx_natural_scrolling' do
     }
 
     it 'sets OSX natural scrolling direction via com.apple.swipescrolldirection' do
-      expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with_boolean(true)
+      expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with(boolean: true)
     end
   end
 
@@ -38,7 +38,7 @@ describe 'lyraphase_workstation::osx_natural_scrolling' do
     }
 
     it 'sets OSX natural scrolling direction via com.apple.swipescrolldirection' do
-      expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with_boolean(false)
+      expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with(boolean: false)
     end
   end
 

--- a/spec/unit/recipes/osx_natural_scrolling.rb
+++ b/spec/unit/recipes/osx_natural_scrolling.rb
@@ -38,7 +38,7 @@ describe 'lyraphase_workstation::osx_natural_scrolling' do
     }
 
     it 'sets OSX natural scrolling direction via com.apple.swipescrolldirection' do
-      expect(chef_run).to write_osx_defaults(global_domain).with(key: 'com.apple.swipescrolldirection', boolean: false)
+      expect(chef_run).to write_osx_defaults('Disable natural scrolling').with(domain: global_domain, key: 'com.apple.swipescrolldirection', boolean: false)
     end
   end
 

--- a/spec/unit/recipes/osx_natural_scrolling.rb
+++ b/spec/unit/recipes/osx_natural_scrolling.rb
@@ -18,7 +18,7 @@ describe 'lyraphase_workstation::osx_natural_scrolling' do
     }
 
     it 'sets OSX natural scrolling direction via com.apple.swipescrolldirection' do
-      expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with(boolean: true)
+      expect(chef_run).to write_osx_defaults(global_domain).with(key: 'com.apple.swipescrolldirection', boolean: true)
     end
   end
 
@@ -38,7 +38,7 @@ describe 'lyraphase_workstation::osx_natural_scrolling' do
     }
 
     it 'sets OSX natural scrolling direction via com.apple.swipescrolldirection' do
-      expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with(boolean: false)
+      expect(chef_run).to write_osx_defaults(global_domain).with(key: 'com.apple.swipescrolldirection', boolean: false)
     end
   end
 

--- a/spec/unit/recipes/osx_natural_scrolling.rb
+++ b/spec/unit/recipes/osx_natural_scrolling.rb
@@ -18,7 +18,13 @@ describe 'lyraphase_workstation::osx_natural_scrolling' do
     }
 
     it 'sets OSX natural scrolling direction via com.apple.swipescrolldirection' do
-      expect(chef_run).to write_osx_defaults(global_domain).with(key: 'com.apple.swipescrolldirection', boolean: true)
+      chef_run.converge(described_recipe)
+      # Workaround a very weird problem with ChefSpec Matcher arity being different on Chef 13 vs 11 & 12
+      if self.method(:write_osx_defaults).arity == 1
+        expect(chef_run).to write_osx_defaults('Disable natural scrolling').with(domain: global_domain, key: 'com.apple.swipescrolldirection', boolean: true)
+      elsif self.method(:write_osx_defaults).arity == 2
+        expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with(boolean: true)
+      end
     end
   end
 
@@ -38,7 +44,13 @@ describe 'lyraphase_workstation::osx_natural_scrolling' do
     }
 
     it 'sets OSX natural scrolling direction via com.apple.swipescrolldirection' do
-      expect(chef_run).to write_osx_defaults('Disable natural scrolling').with(domain: global_domain, key: 'com.apple.swipescrolldirection', boolean: false)
+      chef_run.converge(described_recipe)
+      # Workaround a very weird problem with ChefSpec Matcher arity being different on Chef 13 vs 11 & 12
+      if self.method(:write_osx_defaults).arity == 1
+        expect(chef_run).to write_osx_defaults('Disable natural scrolling').with(domain: global_domain, key: 'com.apple.swipescrolldirection', boolean: false)
+      elsif self.method(:write_osx_defaults).arity == 2
+        expect(chef_run).to write_osx_defaults(global_domain, 'com.apple.swipescrolldirection').with(boolean: false)
+      end
     end
   end
 

--- a/spec/unit/recipes/traktor_audio_2_spec.rb
+++ b/spec/unit/recipes/traktor_audio_2_spec.rb
@@ -140,7 +140,7 @@ describe 'lyraphase_workstation::traktor_audio_2' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults(cf_bundle_id).with(key: 'NSAppSleepDisabled', boolean: true)
+          expect(chef_run).to write_osx_defaults("Disable App Nap for #{cf_bundle_id}").with(domain: cf_bundle_id, key: 'NSAppSleepDisabled', boolean: true)
         end
       end
     end

--- a/spec/unit/recipes/traktor_audio_2_spec.rb
+++ b/spec/unit/recipes/traktor_audio_2_spec.rb
@@ -33,6 +33,13 @@ describe 'lyraphase_workstation::traktor_audio_2' do
   end
 
 
+## Fauxhai 5.5.0 Adds support for:
+# 10.13
+## Fauxhai 5.3.0 in ChefDK  2.3.1 only supports the following mac_os_x versions:
+# 10.10
+# 10.11
+# 10.12
+# 10.13
 ## Fauxhai 4.1.0 in ChefDK 1.3.43 only supports the following mac_os_x versions:
 # 10.10
 # 10.11.1
@@ -56,27 +63,61 @@ describe 'lyraphase_workstation::traktor_audio_2' do
   Chef::Log.warn( Gem.loaded_specs["fauxhai"].version )
   Chef::Log.warn( "Is Fauxhai >= 4.0: " )
   Chef::Log.warn( Gem.loaded_specs["fauxhai"].version >= Gem::Version.new('4.0.0') )
+  Chef::Log.warn( "Is Fauxhai >= 5.0: " )
+  Chef::Log.warn( Gem.loaded_specs["fauxhai"].version >= Gem::Version.new('5.0.0') )
+  Chef::Log.warn( "Is Fauxhai < 6.0: " )
+  Chef::Log.warn( Gem.loaded_specs["fauxhai"].version < Gem::Version.new('6.0.0') )
 
-  # Intersection of both version sets (old_platforms & new_platforms)
+  # Intersection of all version sets (old_platforms & new_platforms & fauxhai_5_platforms)
+  # This is used as default platforms to test Array until we detect Fauxhai version
   platforms_to_test = [
-    { platform: 'mac_os_x', version: '10.9.2',  dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Mavericks',     disable_app_nap: true },
-    { platform: 'mac_os_x', version: '10.10',   dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Yosemite',      disable_app_nap: true },
-    { platform: 'mac_os_x', version: '10.11.1', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'El Capitan',    disable_app_nap: true }
+    { platform: 'mac_os_x', version: '10.10',   dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Yosemite',      disable_app_nap: true }
   ]
+  fauxhai_ver = Gem.loaded_specs["fauxhai"].version
+  case
+    when fauxhai_ver < Gem::Version.new('6.0.0') && fauxhai_ver > Gem::Version.new('5.5.0')
+      [
+        { platform: 'mac_os_x', version: '10.11', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'El Capitan',    disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.12', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Sierra',        disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.13', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'High Sierra',   disable_app_nap: true }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
+    when fauxhai_ver < Gem::Version.new('5.5.0') && fauxhai_ver > Gem::Version.new('5.0.0')
+      [
+        { platform: 'mac_os_x', version: '10.11', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'El Capitan',    disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.12', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Sierra',        disable_app_nap: true }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
+    when fauxhai_ver < Gem::Version.new('5.0.0') && fauxhai_ver > Gem::Version.new('4.0.0')
+      [
+        # 10.10 already in union set above
+        { platform: 'mac_os_x', version: '10.9.2',  dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Mavericks',     disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.11.1', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'El Capitan',    disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.12',   dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Sierra',        disable_app_nap: true }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
 
-  if Gem.loaded_specs["fauxhai"].version < Gem::Version.new('4.0.0')
-    [
-      { platform: 'mac_os_x', version: '10.6.8',  dmg_app: 'Traktor Audio 2 2.7.0 Installer Mac', code_name: 'Snow Leopard',  disable_app_nap: false },
-      { platform: 'mac_os_x', version: '10.7.4',  dmg_app: 'Traktor Audio 2 2.7.0 Installer Mac', code_name: 'Lion',          disable_app_nap: false },
-      { platform: 'mac_os_x', version: '10.8.2',  dmg_app: 'Traktor Audio 2 2.7.0 Installer Mac', code_name: 'Mountain Lion', disable_app_nap: false },
-    ].each do |old_platform|
-      platforms_to_test.unshift( old_platform )
+    when fauxhai_ver < Gem::Version.new('4.0.0')
+      [
+        { platform: 'mac_os_x', version: '10.6.8',  dmg_app: 'Traktor Audio 2 2.7.0 Installer Mac', code_name: 'Snow Leopard',  disable_app_nap: false },
+        { platform: 'mac_os_x', version: '10.7.4',  dmg_app: 'Traktor Audio 2 2.7.0 Installer Mac', code_name: 'Lion',          disable_app_nap: false },
+        { platform: 'mac_os_x', version: '10.8.2',  dmg_app: 'Traktor Audio 2 2.7.0 Installer Mac', code_name: 'Mountain Lion', disable_app_nap: false }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
+  end
+
+  if fauxhai_ver >= Gem::Version.new('3.9.0')
+    unless platforms_to_test.select{|x| x[:version] == '10.10'}
+      platforms_to_test.push( { platform: 'mac_os_x', version: '10.12', dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Sierra', disable_app_nap: true } )
     end
   end
 
-  if Gem.loaded_specs["fauxhai"].version >= Gem::Version.new('3.9.0')
-    platforms_to_test.push( { platform: 'mac_os_x', version: '10.12',  dmg_app: 'Traktor Audio 2 2.8.0 Installer Mac', code_name: 'Sierra', disable_app_nap: true } )
-  end
+  Chef::Log.warn( "Detected Platforms to Test: " )
+  Chef::Log.warn( platforms_to_test )
 
 
   platforms_to_test.each do |os|

--- a/spec/unit/recipes/traktor_audio_2_spec.rb
+++ b/spec/unit/recipes/traktor_audio_2_spec.rb
@@ -140,7 +140,7 @@ describe 'lyraphase_workstation::traktor_audio_2' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with(boolean: true)
+          expect(chef_run).to write_osx_defaults(cf_bundle_id).with(key: 'NSAppSleepDisabled', boolean: true)
         end
       end
     end

--- a/spec/unit/recipes/traktor_audio_2_spec.rb
+++ b/spec/unit/recipes/traktor_audio_2_spec.rb
@@ -99,7 +99,7 @@ describe 'lyraphase_workstation::traktor_audio_2' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with_boolean(true)
+          expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with(boolean: true)
         end
       end
     end

--- a/spec/unit/recipes/traktor_audio_2_spec.rb
+++ b/spec/unit/recipes/traktor_audio_2_spec.rb
@@ -140,7 +140,14 @@ describe 'lyraphase_workstation::traktor_audio_2' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults("Disable App Nap for #{cf_bundle_id}").with(domain: cf_bundle_id, key: 'NSAppSleepDisabled', boolean: true)
+          # Chef::Log.warn("METHOD: #{self.method(:write_osx_defaults)}")
+          # Chef::Log.warn("ARITY: #{self.method(:write_osx_defaults).arity}")
+          # Workaround a very weird problem with ChefSpec Matcher arity being different on Chef 13 vs 11 & 12
+          if self.method(:write_osx_defaults).arity == 1
+            expect(chef_run).to write_osx_defaults("Disable App Nap for #{cf_bundle_id}").with(domain: cf_bundle_id, key: 'NSAppSleepDisabled', boolean: true)
+          elsif self.method(:write_osx_defaults).arity == 2
+            expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with(boolean: true)
+          end
         end
       end
     end

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -137,7 +137,7 @@ describe 'lyraphase_workstation::traktor' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with_boolean(true)
+          expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with(boolean: true)
         end
       end
     end

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -65,43 +65,48 @@ describe 'lyraphase_workstation::traktor' do
   Chef::Log.warn( Gem.loaded_specs["fauxhai"].version < Gem::Version.new('6.0.0') )
 
   # Intersection of all version sets (old_platforms & new_platforms & fauxhai_5_platforms)
+  # This is used as default platforms to test Array until we detect Fauxhai version
   platforms_to_test = [
     { platform: 'mac_os_x', version: '10.10',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Yosemite',      disable_app_nap: true }
   ]
+  fauxhai_ver = Gem.loaded_specs["fauxhai"].version
+  case
+    when fauxhai_ver < Gem::Version.new('6.0.0') && fauxhai_ver > Gem::Version.new('5.0.0')
+      [
+        { platform: 'mac_os_x', version: '10.11',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.12',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra',        disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.13',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'High Sierra',   disable_app_nap: true }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
+    when fauxhai_ver < Gem::Version.new('5.0.0') && fauxhai_ver > Gem::Version.new('4.0.0')
+      [
+        # 10.10 already in union set above
+        { platform: 'mac_os_x', version: '10.9.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mavericks',     disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.11.1', dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.12',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra',        disable_app_nap: true }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
 
-  if Gem.loaded_specs["fauxhai"].version < Gem::Version.new('6.0.0')
-    [
-      { platform: 'mac_os_x', version: '10.11',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true },
-      { platform: 'mac_os_x', version: '10.12',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra',        disable_app_nap: true },
-      { platform: 'mac_os_x', version: '10.13',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'High Sierra',   disable_app_nap: true }
-    ].each do |old_platform|
-      platforms_to_test.unshift( old_platform )
+    when fauxhai_ver < Gem::Version.new('4.0.0')
+      [
+        { platform: 'mac_os_x', version: '10.6.8',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Snow Leopard',  disable_app_nap: false },
+        { platform: 'mac_os_x', version: '10.7.4',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Lion',          disable_app_nap: false },
+        { platform: 'mac_os_x', version: '10.8.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mountain Lion', disable_app_nap: false }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
+  end
+
+  if fauxhai_ver >= Gem::Version.new('3.9.0')
+    unless platforms_to_test.select{|x| x[:version] == '10.10'}
+      platforms_to_test.push( { platform: 'mac_os_x', version: '10.12',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra', disable_app_nap: true } )
     end
   end
 
-  if Gem.loaded_specs["fauxhai"].version < Gem::Version.new('5.0.0')
-    [
-      { platform: 'mac_os_x', version: '10.9.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mavericks',     disable_app_nap: true },
-      { platform: 'mac_os_x', version: '10.11.1', dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true }
-    ].each do |old_platform|
-      platforms_to_test.unshift( old_platform )
-    end
-  end
-
-  if Gem.loaded_specs["fauxhai"].version < Gem::Version.new('4.0.0')
-    [
-      { platform: 'mac_os_x', version: '10.6.8',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Snow Leopard',  disable_app_nap: false },
-      { platform: 'mac_os_x', version: '10.7.4',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Lion',          disable_app_nap: false },
-      { platform: 'mac_os_x', version: '10.8.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mountain Lion', disable_app_nap: false }
-    ].each do |old_platform|
-      platforms_to_test.unshift( old_platform )
-    end
-  end
-
-  if Gem.loaded_specs["fauxhai"].version >= Gem::Version.new('3.9.0')
-    platforms_to_test.push( { platform: 'mac_os_x', version: '10.12',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra', disable_app_nap: true } )
-  end
-
+  Chef::Log.warn( "Detected Platforms to Test: " )
+  Chef::Log.warn( platforms_to_test )
 
   platforms_to_test.each do |os|
     context "on #{os[:platform].split('_').map(&:capitalize).join(' ')} #{os[:version]} (#{os[:code_name]})" do

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -137,7 +137,7 @@ describe 'lyraphase_workstation::traktor' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with(boolean: true)
+          expect(chef_run).to write_osx_defaults(cf_bundle_id).with(key: 'NSAppSleepDisabled', boolean: true)
         end
       end
     end

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -137,7 +137,12 @@ describe 'lyraphase_workstation::traktor' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults("Disable App Nap for #{cf_bundle_id}").with(domain: cf_bundle_id, key: 'NSAppSleepDisabled', boolean: true)
+          # Workaround a very weird problem with ChefSpec Matcher arity being different on Chef 13 vs 11 & 12
+          if self.method(:write_osx_defaults).arity == 1
+            expect(chef_run).to write_osx_defaults("Disable App Nap for #{cf_bundle_id}").with(domain: cf_bundle_id, key: 'NSAppSleepDisabled', boolean: true)
+          elsif self.method(:write_osx_defaults).arity == 2
+            expect(chef_run).to write_osx_defaults(cf_bundle_id, 'NSAppSleepDisabled').with(boolean: true)
+          end
         end
       end
     end

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -137,7 +137,7 @@ describe 'lyraphase_workstation::traktor' do
 
       if os[:disable_app_nap]
         it "disables app nap" do
-          expect(chef_run).to write_osx_defaults(cf_bundle_id).with(key: 'NSAppSleepDisabled', boolean: true)
+          expect(chef_run).to write_osx_defaults("Disable App Nap for #{cf_bundle_id}").with(domain: cf_bundle_id, key: 'NSAppSleepDisabled', boolean: true)
         end
       end
     end

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -31,6 +31,8 @@ describe 'lyraphase_workstation::traktor' do
     end
   end
 
+## Fauxhai 5.5.0 Adds support for:
+# 10.13
 ## Fauxhai 5.3.0 in ChefDK  2.3.1 only supports the following mac_os_x versions:
 # 10.10
 # 10.11
@@ -71,11 +73,18 @@ describe 'lyraphase_workstation::traktor' do
   ]
   fauxhai_ver = Gem.loaded_specs["fauxhai"].version
   case
-    when fauxhai_ver < Gem::Version.new('6.0.0') && fauxhai_ver > Gem::Version.new('5.0.0')
+    when fauxhai_ver < Gem::Version.new('6.0.0') && fauxhai_ver > Gem::Version.new('5.5.0')
       [
         { platform: 'mac_os_x', version: '10.11',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true },
         { platform: 'mac_os_x', version: '10.12',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra',        disable_app_nap: true },
         { platform: 'mac_os_x', version: '10.13',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'High Sierra',   disable_app_nap: true }
+      ].each do |old_platform|
+        platforms_to_test.unshift( old_platform )
+      end
+    when fauxhai_ver < Gem::Version.new('5.5.0') && fauxhai_ver > Gem::Version.new('5.0.0')
+      [
+        { platform: 'mac_os_x', version: '10.11',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true },
+        { platform: 'mac_os_x', version: '10.12',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra',        disable_app_nap: true }
       ].each do |old_platform|
         platforms_to_test.unshift( old_platform )
       end

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -31,6 +31,11 @@ describe 'lyraphase_workstation::traktor' do
     end
   end
 
+## Fauxhai 5.3.0 in ChefDK  2.3.1 only supports the following mac_os_x versions:
+# 10.10
+# 10.11
+# 10.12
+# 10.13
 ## Fauxhai 4.1.0 in ChefDK 1.3.43 only supports the following mac_os_x versions:
 # 10.10
 # 10.11.1
@@ -54,21 +59,40 @@ describe 'lyraphase_workstation::traktor' do
   Chef::Log.warn( Gem.loaded_specs["fauxhai"].version )
   Chef::Log.warn( "Is Fauxhai >= 4.0: " )
   Chef::Log.warn( Gem.loaded_specs["fauxhai"].version >= Gem::Version.new('4.0.0') )
+  Chef::Log.warn( "Is Fauxhai >= 5.0: " )
+  Chef::Log.warn( Gem.loaded_specs["fauxhai"].version >= Gem::Version.new('5.0.0') )
+  Chef::Log.warn( "Is Fauxhai < 6.0: " )
+  Chef::Log.warn( Gem.loaded_specs["fauxhai"].version < Gem::Version.new('6.0.0') )
 
-  # Intersection of both version sets (old_platforms & new_platforms)
+  # Intersection of all version sets (old_platforms & new_platforms & fauxhai_5_platforms)
   platforms_to_test = [
-    { platform: 'mac_os_x', version: '10.9.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mavericks',     disable_app_nap: true },
-    { platform: 'mac_os_x', version: '10.10',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Yosemite',      disable_app_nap: true },
-    { platform: 'mac_os_x', version: '10.11.1', dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true }
+    { platform: 'mac_os_x', version: '10.10',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Yosemite',      disable_app_nap: true }
   ]
 
+  if Gem.loaded_specs["fauxhai"].version < Gem::Version.new('6.0.0')
+    [
+      { platform: 'mac_os_x', version: '10.11',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true },
+      { platform: 'mac_os_x', version: '10.12',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Sierra',        disable_app_nap: true },
+      { platform: 'mac_os_x', version: '10.13',   dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'High Sierra',   disable_app_nap: true }
+    ].each do |old_platform|
+      platforms_to_test.unshift( old_platform )
+    end
+  end
 
+  if Gem.loaded_specs["fauxhai"].version < Gem::Version.new('5.0.0')
+    [
+      { platform: 'mac_os_x', version: '10.9.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mavericks',     disable_app_nap: true },
+      { platform: 'mac_os_x', version: '10.11.1', dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'El Capitan',    disable_app_nap: true }
+    ].each do |old_platform|
+      platforms_to_test.unshift( old_platform )
+    end
+  end
 
   if Gem.loaded_specs["fauxhai"].version < Gem::Version.new('4.0.0')
     [
       { platform: 'mac_os_x', version: '10.6.8',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Snow Leopard',  disable_app_nap: false },
       { platform: 'mac_os_x', version: '10.7.4',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Lion',          disable_app_nap: false },
-      { platform: 'mac_os_x', version: '10.8.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mountain Lion', disable_app_nap: false },
+      { platform: 'mac_os_x', version: '10.8.2',  dmg_volumes_dir: 'Traktor Pro 2.6', code_name: 'Mountain Lion', disable_app_nap: false }
     ].each do |old_platform|
       platforms_to_test.unshift( old_platform )
     end


### PR DESCRIPTION
v1.6.0 - Update Ableton Live to 10.0.1
===========================

 - Update Ableton Live `dmg` to version `10.0.1 `!
 - Fix a lot of Chef 13 related ChefSpec failures
   - Update `mac_os_x` platforms tested depending on Fauxhai version detected
   - Fix weird `arity` issue for ChefSpec custom matcher `write_osx_defaults`
   - Fix CHEF-4: node.set is deprecated, use node.default or explicit precedence levels
   - Fix FC086: Chef::EncryptedDataBagItem.load => data_bag_item
   - Updating plist cookbook to v0.9.4 (FORK! b/c original out of date! Now works on Chef 13 too)
   - Fix FC069, FC078: use SPDX.org defined OSI license