### PR TITLE
Add recipe lyraphase_workstation::loopback_alias_ip for re-creating IP alias on lo0 every reboot (For use with Docker for Mac)

### DIFF
--- a/attributes/loopback_alias_ip.rb
+++ b/attributes/loopback_alias_ip.rb
@@ -1,0 +1,2 @@
+default['lyraphase_workstation']['loopback_alias_ip'] = {}
+default['lyraphase_workstation']['loopback_alias_ip']['alias_ip'] = '172.16.222.111'

--- a/recipes/loopback_alias_ip.rb
+++ b/recipes/loopback_alias_ip.rb
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 James Cuzella
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+loopback_alias_ip = nil
+if ! node['lyraphase_workstation']['loopback_alias_ip'].nil? && ! node['lyraphase_workstation']['loopback_alias_ip']['alias_ip'].nil?
+  loopback_alias_ip = node['lyraphase_workstation']['loopback_alias_ip']['alias_ip']
+end
+
+template "/Library/LaunchDaemons/com.runlevel1.lo0.alias.plist" do
+  source "com.runlevel1.lo0.alias.plist.erb"
+  user "root"
+  group "wheel"
+  mode "0644"
+  variables({ loopback_alias_ip: loopback_alias_ip })
+  notifies :run, 'execute[load the com.runlevel1.lo0.alias plist into launchd]'
+end
+
+execute "load the com.runlevel1.lo0.alias plist into launchd" do
+  command "launchctl load -w /Library/LaunchDaemons/com.runlevel1.lo0.alias.plist"
+  user node['lyraphase_workstation']['user']
+  not_if 'launchctl list com.runlevel1.lo0.alias'
+end

--- a/spec/unit/recipes/loopback_alias_ip_spec.rb
+++ b/spec/unit/recipes/loopback_alias_ip_spec.rb
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 James Cuzella
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+
+describe 'lyraphase_workstation::loopback_alias_ip' do
+
+  let(:launchd_plist) { "/Library/LaunchDaemons/com.runlevel1.lo0.alias.plist" }
+  let(:loopback_alias_ip) { '172.16.222.111' }
+
+  let(:chef_run) {
+    klass = ChefSpec.constants.include?(:SoloRunner) ? ChefSpec::SoloRunner : ChefSpec::Runner
+    klass.new(platform: 'mac_os_x', version: '10.11.1') do |node|
+      create_singleton_struct "EtcPasswd", [ :name, :passwd, :uid, :gid, :gecos, :dir, :shell, :change, :uclass, :expire ]
+      node.normal['etc']['passwd']['brubble'] = Struct::EtcPasswd.new('brubble', '********', 501, 20, 'Barney Rubble', '/Users/brubble', '/bin/bash', 0, '', 0)
+      node.normal['lyraphase_workstation']['user'] = 'brubble'
+      node.normal['lyraphase_workstation']['home'] = '/Users/brubble'
+
+      stub_command("which git").and_return('/usr/local/bin/git')
+
+      stub_command('launchctl list com.runlevel1.lo0.alias').and_return(true)
+    end.converge(described_recipe)
+  }
+
+  it 'installs launchd plist for adding IP alias to loopback network interface lo0' do
+    expect(chef_run).to create_template(launchd_plist).with(
+      user:   'root',
+      group:  'wheel',
+      mode:   '0644'
+    )
+    expect(chef_run).to render_file(launchd_plist).with_content(Regexp.new("^\\s+<string>/sbin/ifconfig</string>$"))
+    expect(chef_run).to render_file(launchd_plist).with_content(Regexp.new("^\\s+<string>#{loopback_alias_ip}</string>$"))
+
+    expect(chef_run.template(launchd_plist)).to notify('execute[load the com.runlevel1.lo0.alias plist into launchd]').to(:run)
+  end
+
+  context "when launchd plist is already loaded" do
+    before(:all) do
+      stub_command('launchctl list com.runlevel1.lo0.alias').and_return(true)
+    end
+
+    it "skips loading com.runlevel1.lo0.alias launchd plist file" do
+      expect(chef_run.execute('load the com.runlevel1.lo0.alias plist into launchd')).to do_nothing
+    end
+  end
+end
+

--- a/templates/default/com.runlevel1.lo0.alias.plist.erb
+++ b/templates/default/com.runlevel1.lo0.alias.plist.erb
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+      <key>Label</key>
+      <string>com.runlevel1.lo0.alias</string>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>ProgramArguments</key>
+      <array>
+          <string>/sbin/ifconfig</string>
+          <string>lo0</string>
+          <string>alias</string>
+          <string><%= @loopback_alias_ip %></string>
+          <string>up</string>
+      </array>
+      <key>StandardErrorPath</key>
+      <string>/var/log/loopback-alias.log</string>
+      <key>StandardOutPath</key>
+      <string>/var/log/loopback-alias.log</string>
+      <key>UserName</key>
+      <string>root</string>
+  </dict>
+</plist>


### PR DESCRIPTION
Use case: Docker container == `socks5h://` ==> Alias IP of macOS Host running SSH Tunnel => Bastion Host

[See diagram Gist / source](https://gist.github.com/trinitronx/6427d6454fb3b121fc2ab5ca7ac766bc)


If you use Docker for Mac, running anything in a container presents some networking challenges when a process inside the container needs to connect through tunnels to a Bastion Host and finally to a service within an Amazon VPC.  Recently, I came across [a way to connect from a docker container to a tunnel running on a host](https://forums.docker.com/t/accessing-host-machine-from-within-docker-container/14248/5).  When combined with a [`SOCKS5h` SSH proxy](https://blog.mafr.de/2013/11/24/setting-up-a-socks-proxy-using-openssh/) (**Note the `h`, it's important!**), this allows common utilities such as `curl` to access internal VPC services through this proxy + tunnel!

Here is a diagram of the setup:

![Docker SOCKS5h Proxy Diagram](https://gist.githubusercontent.com/trinitronx/6427d6454fb3b121fc2ab5ca7ac766bc/raw/3ae15b71a550f3b17fc12257322d7e43ab5ba770/docker-socks5h-diagram.svg?sanitize=true)

The way to set this up is to do the following:

    # First, set up docker networking
    docker network create -d bridge --subnet 10.1.123.0/22 --gateway 10.1.123.1 bridgenet
    
    # On Mac OSX, this is required to actually access host services via alias IP
    sudo ifconfig lo0 alias 172.16.222.111
    
    # Next, set up your SSH tunnel via DynamicForward or -D
    # Note that your SSH tunnel tool needs to provide SOCKS5h proxy capability (OpenSSH should, SSH Tunnel.app on Mac also does)
    # For example, let's use port 4711 as in the SSH tunneling blog post example
    # Note we are using the alias IP for interface lo0 on Mac OSX
    ssh -f -N -v -D 172.16.222.111:4711 ssh-bastion-host.example.com
    # You should see this line in output:
    #    debug1: Local forwarding listening on 172.16.222.111 port 4711
    
    # Next, run a Terraform docker container on bridgenet
    docker run -it --rm \
        -v $HOME/.aws:$HOME/.aws:ro \
        --net=bridgenet \
        --add-host proxy.local:172.16.222.111 \
        -v $HOME:$HOME -e HOME \
        -v $(pwd):/wd -w /wd \
        --entrypoint=/bin/sh alpine:latest
    
    # Install curl
    apk update && apk add curl
    # Check that proxy.local is now set as hostname in the container for the alias IP: 172.16.222.111
    cat /etc/hosts
    # You should see this line:
    #     172.16.222.111  proxy.local
    
    # Now, try accessing an internal VPC service or host via socks5h://
    export ALL_PROXY=socks5h://proxy.local:4711; export HTTPS_PROXY=$ALL_PROXY; export HTTP_PROXY=$ALL_PROXY;
    curl -v http://your-service.vpc.local
    # Optional: Check your WAN Egress IP matches either Public IP of bastion host, or NAT Gateway IP (for private subnets)
    curl -v ifconfig.co



For example, you might want to access a web URL that is only resolveable from behind a secure SSH Tunnel (e.g: `-D 172.16.222.111:4711`) to a Bastion Host.  That is to say: you want to access an internal service through a secure SOCKS5 => SSH Tunnel proxy.  (e.g.: `some-internal-only-service.local`, which has DNS record that is only resolveable _after_ the proxy host).

Luckily, most Linux and open source utilities support the standard proxy environment variables: `ALL_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`.  So if you were trying to run `curl https://some-internal-only-service.local` for example:

    docker run -it --rm -u $(id -u):$(id -g) \
        -v $HOME/.aws:$HOME/.aws:ro \
        --net=bridgenet \
        --add-host proxy.local:172.16.222.111 \
        -e ALL_PROXY=socks5h://proxy.local:4711 \
        -e HTTPS_PROXY=socks5h://proxy.local:4711 \
        -e HTTP_PROXY=socks5h://proxy.local:4711 \
        -v $HOME:$HOME -e HOME \
        -v $(pwd):/wd -w /wd \
        alpine:latest curl -v https://some-internal-only-service.local

This uses the `bridgenet` user defined Docker network, and adds an `/etc/hosts` entry **inside the container** mapping `proxy.local` to the example macOS Host loopback adapter `lo0` alias IP.

In this example, `curl` should be able to connect via `*_PROXY` settings, doing DNS lookup after the proxy (e.g: SSH Tunnel to Bastion Host), and finally connect to `some-internal-only-service.local` to get a response!


 - No known issues for simply adding an alias IP to `lo0` interface (e.g.: `sudo ifconfig lo0 alias 172.16.222.111`)
 - If your use case for this alias IP [matches mine][1], and involves Terraform or Golang utilities... then you may run into problems with DNS resolution & `socks5h://`.  Unless the utility knows how to proxy DNS through SOCKS5, it probably won't work like most other things.


Note: Most tools built with Golang (e.g. [Terraform](https://github.com/hashicorp/terraform/issues/17754)) do not yet support `socks5h://` proxy URLs.  This is most likely due to the known issue in Golang's `x/net/proxy` or "`Dialer`" libraries.  So, there is no support yet for these standard `*_PROXY` variables using `socks5h://`.  For example: without the **`h` form** of SOCKS5 protocol (`socks5h://`), terraform cannot resolve internal AWS VPC DNS names _through the proxy_ such as internal VPC Route53 private zone records.

The good news is that whenever this issue is solved upstream in Golang, those tools will also support SOCKS5h to tunnel correctly!


There is light at the end of the tunnel! (Pun intended)

There is an [upstream bug in Golang to ask for `socks5h://` support in `x/net/proxy`](https://github.com/golang/go/issues/13454) (golang/go#13454).  If this is ever fixed, perhaps Golang code that uses standard `x/net/proxy` library will _just work_!

References:

 - [user-defined networks](https://docs.docker.com/network/bridge/##differences-between-user-defined-bridges-and-the-default-bridge)
 - [Docker forum thread: Connecting docker container to macOS Host](https://forums.docker.com/t/accessing-host-machine-from-within-docker-container/14248/13)
 - [Terraform enhancement request for SOCKS5h support and Explanation of Use Case](https://github.com/hashicorp/terraform/issues/17754#issuecomment-383227407)

[1]: https://gist.github.com/trinitronx/6427d6454fb3b121fc2ab5ca7ac766bc