### PR TITLE
Fix plist file resources

### DIFF
--- a/recipes/airfoil.rb
+++ b/recipes/airfoil.rb
@@ -45,5 +45,5 @@ plist_file airfoil_plist_resource_name do
   domain airfoil_domain if ! airfoil_domain.nil?
   owner node['lyraphase_workstation']['user']
   mode 0600
-  action :update
+  action :create
 end

--- a/recipes/gpg21.rb
+++ b/recipes/gpg21.rb
@@ -68,7 +68,7 @@ plist_file gpgtools_launchagent_plist_file do
   owner 'root'
   group 'wheel'
   mode 0600
-  action :update
+  action :create
 end
 
 ruby_block "add StreamLocalBindUnlink to sshd config" do

--- a/spec/unit/recipes/airfoil_spec.rb
+++ b/spec/unit/recipes/airfoil_spec.rb
@@ -438,7 +438,7 @@ describe "lyraphase_workstation::airfoil" do
     #   f.write(test_file.open("rb") { |f| f.read })
     # end
     # expect(test_file.open("rb") { |f| f.read }).to eq(updated_content)
-    expect(chef_run).to update_plist_file('plist_file_push_spec.plist')
+    expect(chef_run).to create_plist_file('plist_file_push_spec.plist')
   end
 
   after(:all) do

--- a/spec/unit/recipes/gpg21_spec.rb
+++ b/spec/unit/recipes/gpg21_spec.rb
@@ -69,7 +69,7 @@ describe 'lyraphase_workstation::gpg21' do
   end
 
   it "disables the gpgtools launchd plist file" do
-    expect(chef_run).to update_plist_file(gpgtools_plist_file_test)
+    expect(chef_run).to create_plist_file(gpgtools_plist_file_test)
   end
 
   context "when launchd plist is already loaded" do


### PR DESCRIPTION
Fix ChefSpec tests on `plist_file` resources due to upstream cookbook API breakage: carsomyr/chef-plist@b66cf5a243