### PR TITLE
Add bashrc recipe

### DIFF
--- a/attributes/bashrc.rb
+++ b/attributes/bashrc.rb
@@ -1,0 +1,4 @@
+default['lyraphase_workstation']['bashrc'] = {}
+default['lyraphase_workstation']['bashrc']['user_fullname'] = 'James Cuzella'
+default['lyraphase_workstation']['bashrc']['user_email'] = 'james.cuzella@lyraphase.com'
+default['lyraphase_workstation']['bashrc']['user_gpg_keyid'] = '0x2689A459B1568D09'

--- a/recipes/bashrc.rb
+++ b/recipes/bashrc.rb
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016-2018 James Cuzella
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+bashrc_path = Pathname.new(File.join(node['lyraphase_workstation']['home'], '.bashrc'))
+
+homebrew_github_api_token = data_bag_item('lyraphase_workstation', 'bashrc')['homebrew_github_api_token'] rescue nil
+
+if homebrew_github_api_token.nil? && ! node['lyraphase_workstation']['bashrc']['homebrew_github_api_token'].nil? && ! node['lyraphase_workstation']['bashrc']['homebrew_github_api_token'].nil?
+  homebrew_github_api_token = node['lyraphase_workstation']['bashrc']['homebrew_github_api_token']
+end
+
+
+template bashrc_path do
+  source "bashrc.erb"
+  user node['lyraphase_workstation']['user']
+  mode "0644"
+  variables({ user_home: node['lyraphase_workstation']['home'],
+    user_fullname:  node['lyraphase_workstation']['bashrc']['user_fullname'],
+    user_email:     node['lyraphase_workstation']['bashrc']['user_email'],
+    user_gpg_keyid: node['lyraphase_workstation']['bashrc']['user_gpg_keyid'],
+    homebrew_github_api_token: homebrew_github_api_token
+  })
+end

--- a/spec/unit/recipes/bash4_spec.rb
+++ b/spec/unit/recipes/bash4_spec.rb
@@ -46,7 +46,7 @@ describe 'lyraphase_workstation::bash4' do
     end.converge(described_recipe)
   }
 
-  it 'installs gnugpg21 via homebrew' do
+  it 'installs bash & bash-completion@2 via homebrew' do
     [
       'bash',
       'bash-completion@2'

--- a/spec/unit/recipes/bashrc_spec.rb
+++ b/spec/unit/recipes/bashrc_spec.rb
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016-2018 James Cuzella
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'spec_helper'
+
+describe 'lyraphase_workstation::bashrc' do
+
+  let(:bashrc_path) { '/Users/brubble/.bashrc' }
+
+  let(:chef_run) {
+    klass = ChefSpec.constants.include?(:SoloRunner) ? ChefSpec::SoloRunner : ChefSpec::Runner
+    klass.new(platform: 'mac_os_x', version: '10.11.1') do |node|
+      create_singleton_struct "EtcPasswd", [ :name, :passwd, :uid, :gid, :gecos, :dir, :shell, :change, :uclass, :expire ]
+      node.normal['etc']['passwd']['brubble'] = Struct::EtcPasswd.new('brubble', '********', 501, 20, 'Barney Rubble', '/Users/brubble', '/bin/bash', 0, '', 0)
+      node.normal['lyraphase_workstation']['user'] = 'brubble'
+      node.normal['lyraphase_workstation']['home'] = '/Users/brubble'
+
+      stub_command("dscl /Search -read '/Users/brubble' UserShell | grep -q '\/usr\/local\/bin\/bash'").and_return(false)
+    end.converge(described_recipe)
+  }
+
+  it 'installs custom .bashrc into user homedir' do
+    expect(chef_run).to create_file(bashrc_path).with(
+      user:   'brubble',
+      mode: '0644'
+    )
+
+    expect(chef_run).to render_file(bashrc_path) #.with_content()
+  end
+
+end
+


### PR DESCRIPTION
- Adding new initial recipe for `lyraphase_workstation::bashrc`.  Note: `bashrc.erb` template is expected to be available by wrapper cookbook at this point.  Future changes may introduce my default `.bashrc` file.