### PR TITLE
Fixing TravisCI build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+# RuboCop will start looking for the configuration file in the directory
+# where the inspected file is and continue its way up to the root directory.
+#
+# See https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md
+AllCops:
+  Include:
+    - Cheffile
+    - Gemfile
+    - Rakefile
+    - attributes/*
+    - libraries/*
+    - recipes/*
+  Exclude:
+   - templates/**/*
+   - cookbooks/**/*
+   - tmp/**/*
+
+LineLength:
+  Max: 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_script:
 
 script:
   - rake berks
-  - rake knife
   - rake foodcritic
   - rake chefspec
   - find /opt/chefdk/embedded/lib/ruby/gems/  -type f -iwholename '*/fauxhai-*/lib/fauxhai/platforms/mac_os_x/*'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ end
 group :lint do
   gem 'foodcritic', '~> 15.1'
   gem 'cucumber-core', '~> 3.2.1' # Pin cucumber-core to 3.2.1 to fix cucumber/cucumber#483
-#  gem 'rubocop', '~> 0.34' # Too strict & not pragmatic... Bleh!
+  # gem 'rubocop', '~> 0.34' # Too strict & not pragmatic... Bleh!
+  gem 'cookstyle', '~> 5.6' # Based on rubocop... Bleh!
 end
 
 group :update_fauxhai do
@@ -39,10 +40,10 @@ group :development do
 #  gem 'ruby_gntp'
   gem 'growl'
   gem 'rb-fsevent'
-  gem 'guard', '~> 2.13'
+  gem 'guard', '~> 2.15'
   gem 'guard-kitchen'
   gem 'guard-foodcritic', '~> 3.0'
   gem 'guard-rspec'
-  gem 'guard-rubocop'
+#  gem 'guard-rubocop'
   gem 'mixlib-versioning'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -17,10 +17,18 @@ task :berks do
 end
 
 # http://wiki.opscode.com/display/chef/Managing+Cookbooks+With+Knife#ManagingCookbooksWithKnife-test
-desc "Test cookbooks via knife"
+desc "Test cookbooks via knife -- NOTE: knife cookbook test was deprecated as of Chef 15.0.29"
 task :knife do
   cookbook_path = ENV['TRAVIS_BUILD_DIR'] ? ENV['TRAVIS_BUILD_DIR'] + '/../' : '.././'
   sh "knife cookbook test -c test/.chef/knife.rb -o #{cookbook_path} -a"
+end
+
+# Newer CookStyle target
+# Don't use this unless you're a style Gestapo
+require 'cookstyle'
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new do |rubocop|
+    rubocop.options << '--display-cop-names'
 end
 
 # https://github.com/acrmp/chefspec

--- a/spec/unit/recipes/traktor_audio_2_spec.rb
+++ b/spec/unit/recipes/traktor_audio_2_spec.rb
@@ -33,7 +33,7 @@ describe 'lyraphase_workstation::traktor_audio_2' do
   end
 
 
-## Fauxhai 6.8.0 in ChefDK <??unreleased??>
+## Fauxhai 6.8.0 in ChefDK 3.4
 # Adds support for: 10.14
 # Removed support for: 10.10
 # Support List:
@@ -89,7 +89,7 @@ describe 'lyraphase_workstation::traktor_audio_2' do
   ]
   fauxhai_ver = Gem.loaded_specs["fauxhai"].version
   case
-    when fauxhai_ver <= Gem::Version.new('7.0.0') && fauxhai_ver >= Gem::Version.new('6.8.0')
+    when fauxhai_ver <= Gem::Version.new('8.0.0') && fauxhai_ver >= Gem::Version.new('6.8.0')
       platforms_to_test = []
       # 10.10 DEPRECATED in Fauxhai 6.8.0 ... no more similarity with previous mac_os_x platform sets
       [

--- a/spec/unit/recipes/traktor_spec.rb
+++ b/spec/unit/recipes/traktor_spec.rb
@@ -31,7 +31,7 @@ describe 'lyraphase_workstation::traktor' do
     end
   end
 
-## Fauxhai 6.8.0 in ChefDK <??unreleased??>
+## Fauxhai 6.8.0 in ChefDK 3.4
 # Adds support for: 10.14
 # Removed support for: 10.10
 # Support List:
@@ -87,7 +87,7 @@ describe 'lyraphase_workstation::traktor' do
   ]
   fauxhai_ver = Gem.loaded_specs["fauxhai"].version
   case
-    when fauxhai_ver <= Gem::Version.new('7.0.0') && fauxhai_ver >= Gem::Version.new('6.8.0')
+    when fauxhai_ver <= Gem::Version.new('8.0.0') && fauxhai_ver >= Gem::Version.new('6.8.0')
       platforms_to_test = []
       # 10.10 DEPRECATED in Fauxhai 6.8.0 ... no more similarity with previous mac_os_x platform sets
       [


### PR DESCRIPTION
Requesting a pull to trinitronx:master from trinitronx:fix-fauxhai-platforms-for-7.3.0

Changes:

adffa01 (James Cuzella, 8 minutes ago)
   Fix fauxhai up to 8.0.0 (>= 6.8.0) mac_os_x platform versions

   Assuming they won't deprecate any more macOS versions before 8.0.0 This
   also assumes they follow SemVer appropriately.

9068878 (James Cuzella, 35 minutes ago)
   Disable FC121 foodcritic rule. We do not want to break support for Chef <
   14

3adb03e (James Cuzella, 6 months ago)
   lyraphase_workstation::homebrew_sudoers: Fix sudoers line for VirtualBox
   extension pack install steps in Homebrew

907981c
    Disable deprecated knife cookbook test in TravisCI... add demo CookStyle target