### PR TITLE
Bump cookbook to v2.1.2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "james.cuzella@lyraphase.com"
 license          "GPL-3.0+"
 description      "Recipes to Install & Configure my workstation"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.1.1"
+version          "2.1.2"
 chef_version     ">= 12.0" if respond_to?(:chef_version)
 
 source_url 'https://github.com/trinitronx/lyraphase_workstation' if respond_to?(:source_url)


### PR DESCRIPTION
Releas [v2.1.2][1]

[1]: https://github.com/trinitronx/lyraphase_workstation/releases/tag/v2.1.2