### PR TITLE
Update prolific pl2303 driver to v2.0.0_20191204

### DIFF
--- a/attributes/prolific_pl2303_driver.rb
+++ b/attributes/prolific_pl2303_driver.rb
@@ -1,8 +1,15 @@
-default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['source']      = 'http://www.prolific.com.tw/UserFiles/files/PL2303_MacOSX_1_6_1_20160309.zip'
-default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['checksum']    = '14868e4a3c38904760d3445c37bbb5ca2f1024498547645147abbabfcb52eb87'
-default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['file_name']   = 'PL2303_MacOSX_1_6_1_20160309.zip'
-default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['pkg_file']    = 'PL2303_MacOSX_1.6.1_20160309.pkg'
-default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['app_paths']   = [ '/Library/Extensions/ProlificUsbSerial.kext',
+default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['source']      = 'https://lyraphase.com/doc/installers/mac/PL2303HXD_G_Driver_v2.0.0_20191204.zip'
+default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['checksum']    = 'e9fdc23d34df7da62e27819906de7d5cf6f0b78d81b3ffe91f9e8c7baf650897'
+default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['file_name']   = 'PL2303HXD_G_Driver_v2.0.0_20191204.zip'
+default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['pkg_file']    = 'PL2303HXD_G_Driver_v2.0.0_20191112.pkg'
+default['lyraphase_workstation']['prolific_pl2303_driver']['zip']['app_paths']   = [ '/Library/Extensions/Plser.kext',
+                                                                               '/Library/Extensions/Plser.kext/Contents',
+                                                                               '/Library/Extensions/Plser.kext/Contents/_CodeSignature',
+                                                                               '/Library/Extensions/Plser.kext/Contents/_CodeSignature/CodeResources',
+                                                                               '/Library/Extensions/Plser.kext/Contents/Info.plist',
+                                                                               '/Library/Extensions/Plser.kext/Contents/MacOS',
+                                                                               '/Library/Extensions/Plser.kext/Contents/MacOS/Plser',
+                                                                               '/Library/Extensions/ProlificUsbSerial.kext',
                                                                                '/Library/Extensions/ProlificUsbSerial.kext/Contents',
                                                                                '/Library/Extensions/ProlificUsbSerial.kext/Contents/_CodeSignature',
                                                                                '/Library/Extensions/ProlificUsbSerial.kext/Contents/_CodeSignature/CodeResources',


### PR DESCRIPTION
Updates to support MacOS >= 10.13


> PL2303   Drivers & Software
> File Name Release Date  Version File Size
> PL2303HXD_G_Driver_v2.0.0_20191204.zip  2019/12/04  v2.0.0  1296.49KB
> Mac OS X Universal Binary Driver v2.0.0 (PKG file format)
> 
> For Mac OS High Sierra (version 10.15) - see NOTE below.
> For Mac OS High Sierra (version 10.14)
> For Mac OS High Sierra (version 10.13)
> For Mac OS X Sierra (version 10.12)
> For Mac OS X El Capitan (version 10.11)
> For Mac OS X Yosemite (version 10.10)
> For Mac OS X Mavericks (version 10.9)
> For PL2303 H/HX/HXD/EA/RA/SA/TA/TB chip versions
> For Prolific USB VID_067B&PID_2303 Only
> For PL2303GC, GS, GT, GL, GE , GD chip versions
> Includes Driver Installation Manual
> NOTE: Mac OS High Sierra 10.13 introduces a new feature that requires user approval before loading new third-party kernel extensions. Go to System Preferences - Security & Privacy and click Allow.
> 
> https://developer.apple.com/library/content/technotes/tn2459/_index.html

Source: http://www.prolific.com.tw/US/supportDownload.aspx?FileType=56&FileID=133&pcid=85&Page=0

