### PR TITLE
lyraphase_workstation::root_bootstrap_ssh_config: Use macOS Keychain for SSH keys

### DIFF
--- a/spec/unit/recipes/root_bootstrap_ssh_config_spec.rb
+++ b/spec/unit/recipes/root_bootstrap_ssh_config_spec.rb
@@ -87,6 +87,8 @@ describe 'lyraphase_workstation::root_bootstrap_ssh_config' do
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+PreferredAuthentications\s+publickey$/)
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+StrictHostKeyChecking\s+no$/)
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+UserKnownHostsFile\s+\/dev\/null$/)
+      expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+UseKeychain\s+yes$/)
+      expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+AddKeysToAgent\s+yes$/)
     end
   end
 

--- a/templates/default/ssh/root_bootstrap_ssh_config.erb
+++ b/templates/default/ssh/root_bootstrap_ssh_config.erb
@@ -5,6 +5,8 @@ Host github.com
   PreferredAuthentications publickey
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
+  UseKeychain yes
+  AddKeysToAgent yes
   # NOTE: Manually copy this over to new machine
   IdentityFile <%= @home -%>/.ssh/<%= @identity_file -%>
 


### PR DESCRIPTION
- Add UseKeychain=yes & AddKeysToAgent=yes to root ssh config