### PR TITLE
Fix pCloud Drive sublime text settings mac m1

### DIFF
--- a/attributes/sublime_text_settings.rb
+++ b/attributes/sublime_text_settings.rb
@@ -7,3 +7,7 @@ default['lyraphase_workstation']['sublime_text_settings']['shared_files'] =
                                               'Packages',
                                               'Local/License.sublime_license'
                                             ]
+unless File.exists?(default['lyraphase_workstation']['sublime_text_settings']['shared_files_path'])
+  Chef::Log.warn('pCloud Drive installation cannot be automated... please Enable Drive and allow kernel extensions from Recovery mode.')
+  Chef::Log.warn('  https://web.archive.org/web/20211221010410/https://blog.pcloud.com/how-to-install-pcloud-drive-on-apple-devices-with-the-m1-chip/')
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "james.cuzella@lyraphase.com"
 license          "GPL-3.0+"
 description      "Recipes to Install & Configure my workstation"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.2.3"
+version          "3.2.4"
 chef_version     ">= 12.0" if respond_to?(:chef_version)
 
 source_url 'https://github.com/trinitronx/lyraphase_workstation' if respond_to?(:source_url)


### PR DESCRIPTION
v3.2.4
======

Errata
------

 - `lyraphase_workstation::sublime_text_settings`: pCloud Drive cannot be automated on M1 Macs
   - Warn user about [manual steps][1] that must be taken

[1]: https://web.archive.org/web/20211221010410/https://blog.pcloud.com/how-to-install-pcloud-drive-on-apple-devices-with-the-m1-chip/