### PR TITLE
Fix sublime text settings recursive dirs

### DIFF
--- a/attributes/sublime_text_settings.rb
+++ b/attributes/sublime_text_settings.rb
@@ -1,9 +1,13 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/LineLength
 default['lyraphase_workstation']['sublime_text_settings'] = {}
 default['lyraphase_workstation']['sublime_text_settings']['app_support_path'] = "#{node['lyraphase_workstation']['home']}/Library/Application Support/Sublime Text 3"
-default['lyraphase_workstation']['sublime_text_settings']['shared_files_path'] =  "#{node['lyraphase_workstation']['home']}/pCloud Drive/AppData/mac/sublime-text-3"
-default['lyraphase_workstation']['sublime_text_settings']['shared_files'] =
-                                            [
-                                              'Installed Packages',
-                                              'Packages',
-                                              'Local/License.sublime_license'
-                                            ]
+default['lyraphase_workstation']['sublime_text_settings']['shared_files_path'] = "#{node['lyraphase_workstation']['home']}/pCloud Drive/AppData/mac/sublime-text-3"
+default['lyraphase_workstation']['sublime_text_settings']['shared_files'] = [
+  'Installed Packages',
+  'Packages',
+  'Local/License.sublime_license'
+]
+# rubocop:enable Metrics/LineLength

--- a/attributes/sublime_text_settings.rb
+++ b/attributes/sublime_text_settings.rb
@@ -7,7 +7,3 @@ default['lyraphase_workstation']['sublime_text_settings']['shared_files'] =
                                               'Packages',
                                               'Local/License.sublime_license'
                                             ]
-unless File.exists?(default['lyraphase_workstation']['sublime_text_settings']['shared_files_path'])
-  Chef::Log.warn('pCloud Drive installation cannot be automated... please Enable Drive and allow kernel extensions from Recovery mode.')
-  Chef::Log.warn('  https://web.archive.org/web/20211221010410/https://blog.pcloud.com/how-to-install-pcloud-drive-on-apple-devices-with-the-m1-chip/')
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "james.cuzella@lyraphase.com"
 license          "GPL-3.0+"
 description      "Recipes to Install & Configure my workstation"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.2.4"
+version          "3.2.5"
 chef_version     ">= 12.0" if respond_to?(:chef_version)
 
 source_url 'https://github.com/trinitronx/lyraphase_workstation' if respond_to?(:source_url)

--- a/recipes/sublime_text_settings.rb
+++ b/recipes/sublime_text_settings.rb
@@ -1,10 +1,14 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
 #
-# Cookbook Name:: lyraphase_workstation
+# Cookbook:: lyraphase_workstation
 # Recipe:: sublime_text_license
 # Site:: http://www.sublimetext.com/
 #
-# Copyright (C) © 🄯  2015-2021 James Cuzella
-# 
+# License:: GPL-3.0+
+# Copyright:: (C) © 🄯  2015-2020 James Cuzella
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -19,22 +23,23 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-unless File.exists?(node['lyraphase_workstation']['sublime_text_settings']['shared_files_path'])
+unless File.exist?(node['lyraphase_workstation']['sublime_text_settings']['shared_files_path'])
   Chef::Log.warn('pCloud Drive installation cannot be automated... please Enable Drive and allow kernel extensions from Recovery mode.')
   Chef::Log.warn('  https://web.archive.org/web/20211221010410/https://blog.pcloud.com/how-to-install-pcloud-drive-on-apple-devices-with-the-m1-chip/')
   Chef::Log.warn('Sublime Text shared_files_path may not exist until pCloud Drive is enabled!')
 end
 
 node['lyraphase_workstation']['sublime_text_settings']['shared_files'].each do |shared_sublime_file|
-  symlink_target = "#{node['lyraphase_workstation']['sublime_text_settings']['shared_files_path']}/#{shared_sublime_file}"
-  Chef::Log::warn("Sublime Text Settings file not found: #{symlink_target}") if !::File.exist?( symlink_target )
+  symlink_target =
+    "#{node['lyraphase_workstation']['sublime_text_settings']['shared_files_path']}/#{shared_sublime_file}"
+  Chef::Log.warn("Sublime Text Settings file not found: #{symlink_target}") unless ::File.exist?(symlink_target)
 
   symlink_path = "#{node['lyraphase_workstation']['sublime_text_settings']['app_support_path']}/#{shared_sublime_file}"
 
   # Create recursive directories specified in shared_files
   # under app_support_path, except special cases: '.' '..' '/'
   shared_sublime_file_parent_dir = File.dirname(shared_sublime_file)
-  if !['.', '..', '/'].include?(shared_sublime_file_parent_dir)
+  unless ['.', '..', '/'].include?(shared_sublime_file_parent_dir)
     symlink_path_parent_dir = File.dirname(Pathname.new(symlink_path))
     directory symlink_path_parent_dir do
       action :create
@@ -43,23 +48,21 @@ node['lyraphase_workstation']['sublime_text_settings']['shared_files'].each do |
       group 'staff'
       mode '0700'
       # Avoid creating the dir if our symlink target shared file does not exist.
-      not_if { !::File.exist?( symlink_target ) }
+      not_if { !::File.exist?(symlink_target) }
     end
   end
 
   directory symlink_path do
     action :delete
-    only_if { !::File.symlink?( symlink_path ) && (::File.exist?( symlink_path ) || ::Dir.exist?( symlink_path )) }
+    only_if { !::File.symlink?(symlink_path) && (::File.exist?(symlink_path) || ::Dir.exist?(symlink_path)) }
     # Avoid deleting the dir if our symlink target shared file does not exist.
-    not_if { !::File.exist?( symlink_target ) }
+    not_if { !::File.exist?(symlink_target) }
   end
-
 
   link symlink_path do
     to symlink_target
     owner node['lyraphase_workstation']['user']
     mode '0755'
-    not_if { File.symlink?( symlink_target ) }
+    not_if { File.symlink?(symlink_target) }
   end
 end
-

--- a/recipes/sublime_text_settings.rb
+++ b/recipes/sublime_text_settings.rb
@@ -3,7 +3,7 @@
 # Recipe:: sublime_text_license
 # Site:: http://www.sublimetext.com/
 #
-# Copyright (C) © 🄯  2015-2020 James Cuzella
+# Copyright (C) © 🄯  2015-2021 James Cuzella
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,11 +19,34 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+unless File.exists?(node['lyraphase_workstation']['sublime_text_settings']['shared_files_path'])
+  Chef::Log.warn('pCloud Drive installation cannot be automated... please Enable Drive and allow kernel extensions from Recovery mode.')
+  Chef::Log.warn('  https://web.archive.org/web/20211221010410/https://blog.pcloud.com/how-to-install-pcloud-drive-on-apple-devices-with-the-m1-chip/')
+  Chef::Log.warn('Sublime Text shared_files_path may not exist until pCloud Drive is enabled!')
+end
+
 node['lyraphase_workstation']['sublime_text_settings']['shared_files'].each do |shared_sublime_file|
   symlink_target = "#{node['lyraphase_workstation']['sublime_text_settings']['shared_files_path']}/#{shared_sublime_file}"
   Chef::Log::warn("Sublime Text Settings file not found: #{symlink_target}") if !::File.exist?( symlink_target )
 
   symlink_path = "#{node['lyraphase_workstation']['sublime_text_settings']['app_support_path']}/#{shared_sublime_file}"
+
+  # Create recursive directories specified in shared_files
+  # under app_support_path, except special cases: '.' '..' '/'
+  shared_sublime_file_parent_dir = File.dirname(shared_sublime_file)
+  if !['.', '..', '/'].include?(shared_sublime_file_parent_dir)
+    symlink_path_parent_dir = File.dirname(Pathname.new(symlink_path))
+    directory symlink_path_parent_dir do
+      action :create
+      recursive true
+      owner node['lyraphase_workstation']['user']
+      group 'staff'
+      mode '0700'
+      # Avoid creating the dir if our symlink target shared file does not exist.
+      not_if { !::File.exist?( symlink_target ) }
+    end
+  end
+
   directory symlink_path do
     action :delete
     only_if { !::File.symlink?( symlink_path ) && (::File.exist?( symlink_path ) || ::Dir.exist?( symlink_path )) }


### PR DESCRIPTION
Bug Fixes
---------

 - `lyraphase_workstation::sublime_text_settings:`
   - CookStyle fixups for sublime_text_settings
   - Create recursive symlink parent dirs if symlink targets exist
   - Add ChefSpec tests for recursive symlink parent dir creation