### PR TITLE
Use OpenSSH >=8.5 UpdateHostKeys for github.com new keys

### DIFF
--- a/spec/unit/recipes/root_bootstrap_ssh_config_spec.rb
+++ b/spec/unit/recipes/root_bootstrap_ssh_config_spec.rb
@@ -87,6 +87,7 @@ describe 'lyraphase_workstation::root_bootstrap_ssh_config' do
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+PreferredAuthentications\s+publickey$/)
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+StrictHostKeyChecking\s+no$/)
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+UserKnownHostsFile\s+\/dev\/null$/)
+      expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+UpdateHostKeys\s+yes$/)
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+UseKeychain\s+yes$/)
       expect(chef_run).to render_file(root_ssh_config).with_content(/^\s+AddKeysToAgent\s+yes$/)
     end

--- a/templates/default/ssh/root_bootstrap_ssh_config.erb
+++ b/templates/default/ssh/root_bootstrap_ssh_config.erb
@@ -5,6 +5,7 @@ Host github.com
   PreferredAuthentications publickey
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
+  UpdateHostKeys yes
   UseKeychain yes
   AddKeysToAgent yes
   # NOTE: Manually copy this over to new machine


### PR DESCRIPTION
References:

 - https://github.blog/2021-09-01-improving-git-protocol-security-github/
 - https://blog.desdelinux.net/en/openssh-8-5-llega-con-updatehostkeys-correcciones-y-mas/