### PR TITLE
Update AppSupport path for Sublime Text 4

### DIFF
--- a/attributes/sublime_text_settings.rb
+++ b/attributes/sublime_text_settings.rb
@@ -3,7 +3,7 @@
 
 # rubocop:disable Metrics/LineLength
 default['lyraphase_workstation']['sublime_text_settings'] = {}
-default['lyraphase_workstation']['sublime_text_settings']['app_support_path'] = "#{node['lyraphase_workstation']['home']}/Library/Application Support/Sublime Text 3"
+default['lyraphase_workstation']['sublime_text_settings']['app_support_path'] = "#{node['lyraphase_workstation']['home']}/Library/Application Support/Sublime Text"
 default['lyraphase_workstation']['sublime_text_settings']['shared_files_path'] = "#{node['lyraphase_workstation']['home']}/pCloud Drive/AppData/mac/sublime-text-3"
 default['lyraphase_workstation']['sublime_text_settings']['shared_files'] = [
   'Installed Packages',


### PR DESCRIPTION
Default install path moved from `~/Library/Application Support/Sublime Text 3` back to `~/Library/Application Support/Sublime Text`