### PR TITLE
ci: Consolidate matrix job status into single job for branch protection usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,18 @@ jobs:
             export TERM=xterm-color
             log show --color always --last 5m
             KITCHEN_LOCAL_YAML=${{ matrix.KITCHEN_LOCAL_YAML }} kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "syslog"
+
+  integration_result:
+    needs: [integration]
+    if: always()
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: check the jobs # get the matrix job status and combination info
+        run: |
+          job_status=$(curl -X GET -s --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs | jq ".jobs[] | {job_status: .conclusion, matrix: .name}")
+          echo echo ::set-env JOB_STATUS=$job_status
+      - name: Set matrix job status
+        if: contains(env.JOB_STATUS, 'failed')
+        run: |
+          echo 'One or more integration matrix jobs failed!'
+          exit 1


### PR DESCRIPTION
References:

- [Get status of parallel jobs into a single Webhook payload][1]
- [How to use system environment variable in cache actions path?][2]
- [GitHub Actions If contains function not working with env.VARIABLE][3]
- [Status check for a matrix jobs][4]

[1]: https://github.community/t/get-status-of-parallel-jobs-into-a-single-webhook-payload/18077/2
[2]: https://github.community/t/how-to-use-system-environment-variable-in-cache-actions-path/17960/2
[3]: https://github.community/t/github-actions-if-contains-function-not-working-with-env-variable/18131
[4]: https://github.community/t/status-check-for-a-matrix-jobs/127354
