### PR TITLE
lyraphase_workstation::bashrc: Set default HOMEBREW_CASK_OPTS="--no-quarantine"

### DIFF
--- a/templates/default/bashrc.erb
+++ b/templates/default/bashrc.erb
@@ -184,6 +184,9 @@ then
   # Keep old versions for specific formulae
   export HOMEBREW_NO_CLEANUP_FORMULAE=<%= @homebrew_no_cleanup_formulae.join(',') %>
 <% end %>
+  # Remove the com.apple.quarantine extended file attribute for installed Casks
+  export HOMEBREW_CASK_OPTS="--no-quarantine"
+
   # Alias defunkt/hub as git
   eval "$(hub alias -s)"
 


### PR DESCRIPTION
No more need for running the dreaded `xattr -rd /Applications/*.app` command each time a Cask gets upgraded!

References:

- [How to get rid of "application downloaded from the internet" message when installing homebrew casks?][1]
- [New `brew upgrade/reinstall --cask` does not honour `--no-quarantine`][2]
- [UX fix - Properly allow quarantine in '`upgrade`'][3]

[1]: https://apple.stackexchange.com/questions/337320/how-to-get-rid-of-application-downloaded-from-the-internet-message-when-instal
[2]: https://github.com/Homebrew/brew/issues/9139
[3]: https://github.com/Homebrew/brew/pull/10398